### PR TITLE
T3code/thread title override reset

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -602,6 +602,13 @@ async function waitForComposerEditor(): Promise<HTMLElement> {
   );
 }
 
+async function waitForDraftThreadTitleInput(): Promise<HTMLInputElement> {
+  return waitForElement(
+    () => document.querySelector<HTMLInputElement>('[data-testid="draft-thread-title-input"]'),
+    "Unable to find draft thread title input.",
+  );
+}
+
 async function waitForInteractionModeButton(
   expectedLabel: "Chat" | "Plan",
 ): Promise<HTMLButtonElement> {
@@ -1350,6 +1357,139 @@ describe("ChatView timeline estimator parity (full app)", () => {
         .element(page.getByText("Send a message to start the conversation."))
         .toBeInTheDocument();
       await expect.element(page.getByTestId("composer-editor")).toBeInTheDocument();
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("uses the draft title override when creating a new thread", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-new-thread-title-override" as MessageId,
+        targetText: "new thread title override",
+      }),
+    });
+
+    try {
+      const newThreadButton = page.getByTestId("new-thread-button");
+      await expect.element(newThreadButton).toBeInTheDocument();
+      await newThreadButton.click();
+
+      const newThreadPath = await waitForURL(
+        mounted.router,
+        (path) => UUID_ROUTE_RE.test(path),
+        "Route should have changed to a new draft thread UUID.",
+      );
+      const newThreadId = newThreadPath.slice(1) as ThreadId;
+
+      const titleInput = await waitForDraftThreadTitleInput();
+      titleInput.value = "Release planning";
+      titleInput.dispatchEvent(new Event("input", { bubbles: true }));
+
+      useComposerDraftStore
+        .getState()
+        .setPrompt(newThreadId, "Prepare the release checklist and rollout plan.");
+
+      const requestCountBeforeSend = wsRequests.length;
+      const sendButton = await waitForElement(
+        () => document.querySelector<HTMLButtonElement>('button[aria-label="Send message"]'),
+        "Unable to find Send message button.",
+      );
+      sendButton.click();
+
+      let requestsAfterSend: WsRequestEnvelope["body"][] = [];
+      await vi.waitFor(
+        () => {
+          requestsAfterSend = wsRequests.slice(requestCountBeforeSend);
+          expect(
+            requestsAfterSend.some((request) => {
+              if (request._tag !== ORCHESTRATION_WS_METHODS.dispatchCommand) {
+                return false;
+              }
+              const command = request.command;
+              return (
+                typeof command === "object" &&
+                command !== null &&
+                "type" in command &&
+                command.type === "thread.create"
+              );
+            }),
+          ).toBe(true);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      expect(
+        requestsAfterSend.find((request) => {
+          if (request._tag !== ORCHESTRATION_WS_METHODS.dispatchCommand) {
+            return false;
+          }
+          const command = request.command;
+          return (
+            typeof command === "object" &&
+            command !== null &&
+            "type" in command &&
+            command.type === "thread.create"
+          );
+        }),
+      ).toMatchObject({
+        _tag: ORCHESTRATION_WS_METHODS.dispatchCommand,
+        command: {
+          type: "thread.create",
+          threadId: newThreadId,
+          title: "Release planning",
+        },
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("resets the draft title override after navigating away from the new thread", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-reset-draft-title-override" as MessageId,
+        targetText: "reset draft title override",
+      }),
+    });
+
+    try {
+      const newThreadButton = page.getByTestId("new-thread-button");
+      await expect.element(newThreadButton).toBeInTheDocument();
+      await newThreadButton.click();
+
+      const newThreadPath = await waitForURL(
+        mounted.router,
+        (path) => UUID_ROUTE_RE.test(path),
+        "Route should have changed to a new draft thread UUID.",
+      );
+
+      const titleInput = await waitForDraftThreadTitleInput();
+      titleInput.value = "Temporary title";
+      titleInput.dispatchEvent(new Event("input", { bubbles: true }));
+
+      await mounted.router.navigate({
+        to: "/$threadId",
+        params: { threadId: THREAD_ID },
+      });
+      await waitForURL(
+        mounted.router,
+        (path) => path === `/${THREAD_ID}`,
+        "Route should have changed back to the original thread.",
+      );
+
+      await newThreadButton.click();
+      await waitForURL(
+        mounted.router,
+        (path) => path === newThreadPath,
+        "New thread button should reopen the existing draft thread.",
+      );
+
+      const resetTitleInput = await waitForDraftThreadTitleInput();
+      expect(resetTitleInput.value).toBe("");
+      expect(resetTitleInput.placeholder).toBe("New thread");
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -271,6 +271,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const [expandedWorkGroups, setExpandedWorkGroups] = useState<Record<string, boolean>>({});
   const [planSidebarOpen, setPlanSidebarOpen] = useState(false);
   const [isComposerFooterCompact, setIsComposerFooterCompact] = useState(false);
+  const [draftThreadTitleOverride, setDraftThreadTitleOverride] = useState("");
   // Tracks whether the user explicitly dismissed the sidebar for the active turn.
   const planSidebarDismissedForTurnRef = useRef<string | null>(null);
   // When set, the thread-change reset effect will open the sidebar instead of closing it.
@@ -383,6 +384,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     composerDraft.interactionMode ?? activeThread?.interactionMode ?? DEFAULT_INTERACTION_MODE;
   const isServerThread = serverThread !== undefined;
   const isLocalDraftThread = !isServerThread && localDraftThread !== undefined;
+  const trimmedDraftThreadTitleOverride = draftThreadTitleOverride.trim();
   const canCheckoutPullRequestIntoThread = isLocalDraftThread;
   const diffOpen = rawSearch.diff === "1";
   const activeThreadId = activeThread?.id ?? null;
@@ -407,6 +409,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const closePullRequestDialog = useCallback(() => {
     setPullRequestDialogState(null);
   }, []);
+
+  useEffect(() => {
+    setDraftThreadTitleOverride("");
+  }, [threadId]);
 
   const openOrReuseProjectDraftThread = useCallback(
     async (input: { branch: string; worktreePath: string | null; envMode: DraftThreadEnvMode }) => {
@@ -2390,6 +2396,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
         }
       }
       let titleSeed = trimmed;
+      if (isLocalDraftThread && trimmedDraftThreadTitleOverride.length > 0) {
+        titleSeed = trimmedDraftThreadTitleOverride;
+      }
       if (!titleSeed) {
         if (firstComposerImageName) {
           titleSeed = `Image: ${firstComposerImageName}`;
@@ -3283,6 +3292,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
         <ChatHeader
           activeThreadId={activeThread.id}
           activeThreadTitle={activeThread.title}
+          draftThreadTitleOverride={isLocalDraftThread ? draftThreadTitleOverride : null}
           activeProjectId={activeProject?.id ?? null}
           activeProjectName={activeProject?.name}
           activeProjectRemote={activeProject?.remote ?? null}
@@ -3306,6 +3316,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
           onUpdateProjectScript={updateProjectScript}
           onDeleteProjectScript={deleteProjectScript}
           onToggleDiff={onToggleDiff}
+          onDraftThreadTitleOverrideChange={isLocalDraftThread ? setDraftThreadTitleOverride : null}
         />
       </header>
 

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -11,6 +11,7 @@ import GitActionsControl from "../GitActionsControl";
 import type { GitQueryTarget } from "~/lib/gitReactQuery";
 import { DiffIcon } from "lucide-react";
 import { Badge } from "../ui/badge";
+import { Input } from "../ui/input";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import ProjectScriptsControl, { type NewProjectScriptInput } from "../ProjectScriptsControl";
 import { Toggle } from "../ui/toggle";
@@ -20,6 +21,7 @@ import { OpenInPicker } from "./OpenInPicker";
 interface ChatHeaderProps {
   activeThreadId: ThreadId;
   activeThreadTitle: string;
+  draftThreadTitleOverride: string | null;
   activeProjectId: ProjectId | null;
   activeProjectName: string | undefined;
   activeProjectRemote: ProjectRemoteTarget | null;
@@ -39,11 +41,13 @@ interface ChatHeaderProps {
   onUpdateProjectScript: (scriptId: string, input: NewProjectScriptInput) => Promise<void>;
   onDeleteProjectScript: (scriptId: string) => Promise<void>;
   onToggleDiff: () => void;
+  onDraftThreadTitleOverrideChange: ((value: string) => void) | null;
 }
 
 export const ChatHeader = memo(function ChatHeader({
   activeThreadId,
   activeThreadTitle,
+  draftThreadTitleOverride,
   activeProjectId,
   activeProjectName,
   activeProjectRemote,
@@ -63,17 +67,31 @@ export const ChatHeader = memo(function ChatHeader({
   onUpdateProjectScript,
   onDeleteProjectScript,
   onToggleDiff,
+  onDraftThreadTitleOverrideChange,
 }: ChatHeaderProps) {
   return (
     <div className="flex min-w-0 flex-1 items-center gap-2">
       <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden sm:gap-3">
         <SidebarTrigger className="size-7 shrink-0 md:hidden" />
-        <h2
-          className="min-w-0 shrink truncate text-sm font-medium text-foreground"
-          title={activeThreadTitle}
-        >
-          {activeThreadTitle}
-        </h2>
+        {onDraftThreadTitleOverrideChange ? (
+          <Input
+            nativeInput
+            size="sm"
+            value={draftThreadTitleOverride ?? ""}
+            onChange={(event) => onDraftThreadTitleOverrideChange(event.currentTarget.value)}
+            placeholder={activeThreadTitle}
+            aria-label="New thread title"
+            data-testid="draft-thread-title-input"
+            className="min-w-0 max-w-md flex-1"
+          />
+        ) : (
+          <h2
+            className="min-w-0 shrink truncate text-sm font-medium text-foreground"
+            title={activeThreadTitle}
+          >
+            {activeThreadTitle}
+          </h2>
+        )}
         {activeProjectName && (
           <Badge variant="outline" className="min-w-0 shrink truncate">
             {activeProjectName}


### PR DESCRIPTION
- Add editable title input in the chat header for local draft threads
- Use the override as `thread.create` title when sending the first message
- Clear the override when navigating away, with browser tests covering both flows

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
