### PR TITLE
Add desktop app close behavior settings

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -18,6 +18,7 @@ import {
 import type { MenuItemConstructorOptions } from "electron";
 import * as Effect from "effect/Effect";
 import type {
+  DesktopAppCloseBehavior,
   DesktopTheme,
   DesktopUpdateActionResult,
   DesktopUpdateState,
@@ -56,6 +57,7 @@ const UPDATE_STATE_CHANNEL = "desktop:update-state";
 const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
 const UPDATE_DOWNLOAD_CHANNEL = "desktop:update-download";
 const UPDATE_INSTALL_CHANNEL = "desktop:update-install";
+const APP_CLOSE_BEHAVIOR_SET_CHANNEL = "desktop:app-close-behavior:set";
 const STATE_DIR =
   process.env.T3CODE_STATE_DIR?.trim() || Path.join(OS.homedir(), ".t3", "userdata");
 const DESKTOP_SCHEME = "t3";
@@ -75,8 +77,24 @@ const AUTO_UPDATE_STARTUP_DELAY_MS = 15_000;
 const AUTO_UPDATE_POLL_INTERVAL_MS = 4 * 60 * 60 * 1000;
 const DESKTOP_UPDATE_CHANNEL = "latest";
 const DESKTOP_UPDATE_ALLOW_PRERELEASE = false;
+const DESKTOP_SETTINGS_PATH = Path.join(STATE_DIR, "desktop-settings.json");
+const DESKTOP_BACKEND_STATE_PATH = Path.join(STATE_DIR, "desktop-backend.json");
+const DESKTOP_BACKEND_RUNTIME_PATH = "/api/desktop/runtime";
+const DEFAULT_DESKTOP_APP_CLOSE_BEHAVIOR: DesktopAppCloseBehavior = "terminate_all_agents";
 
 type DesktopUpdateErrorContext = DesktopUpdateState["errorContext"];
+type DesktopBackendControlAction = "shutdown-server" | "stop-local-sessions";
+
+interface PersistedDesktopSettings {
+  appCloseBehavior: DesktopAppCloseBehavior;
+}
+
+interface PersistedDesktopBackendState {
+  port: number;
+  authToken: string;
+  pid: number | null;
+  startedAt: string;
+}
 
 let mainWindow: BrowserWindow | null = null;
 let backendProcess: ChildProcess.ChildProcess | null = null;
@@ -86,6 +104,8 @@ let backendWsUrl = "";
 let restartAttempt = 0;
 let restartTimer: ReturnType<typeof setTimeout> | null = null;
 let isQuitting = false;
+let quitPrepared = false;
+let quitPreparationPromise: Promise<void> | null = null;
 let desktopProtocolRegistered = false;
 let aboutCommitHashCache: string | null | undefined;
 let desktopLogSink: RotatingFileSink | null = null;
@@ -100,6 +120,115 @@ const desktopRuntimeInfo = resolveDesktopRuntimeInfo({
 });
 const initialUpdateState = (): DesktopUpdateState =>
   createInitialDesktopUpdateState(app.getVersion(), desktopRuntimeInfo);
+let desktopAppCloseBehavior =
+  readPersistedDesktopSettings().appCloseBehavior ?? DEFAULT_DESKTOP_APP_CLOSE_BEHAVIOR;
+
+function isDesktopAppCloseBehavior(value: unknown): value is DesktopAppCloseBehavior {
+  return (
+    value === "terminate_all_agents" ||
+    value === "terminate_local_agents_only" ||
+    value === "terminate_no_agents"
+  );
+}
+
+function ensureStateDirExists(): void {
+  FS.mkdirSync(STATE_DIR, { recursive: true });
+}
+
+function readJsonFile(filePath: string): unknown {
+  const raw = FS.readFileSync(filePath, "utf8");
+  return JSON.parse(raw) as unknown;
+}
+
+function writeJsonFile(filePath: string, value: unknown): void {
+  ensureStateDirExists();
+  FS.writeFileSync(filePath, JSON.stringify(value, null, 2));
+}
+
+function deleteFileIfExists(filePath: string): void {
+  try {
+    FS.rmSync(filePath, { force: true });
+  } catch {
+    // Ignore cleanup failures during shutdown/startup recovery.
+  }
+}
+
+function readPersistedDesktopSettings(): PersistedDesktopSettings {
+  try {
+    const parsed = readJsonFile(DESKTOP_SETTINGS_PATH);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      isDesktopAppCloseBehavior((parsed as { appCloseBehavior?: unknown }).appCloseBehavior)
+    ) {
+      return {
+        appCloseBehavior: (parsed as { appCloseBehavior: DesktopAppCloseBehavior })
+          .appCloseBehavior,
+      };
+    }
+  } catch {
+    // Fall back to defaults for missing or malformed files.
+  }
+
+  return {
+    appCloseBehavior: DEFAULT_DESKTOP_APP_CLOSE_BEHAVIOR,
+  };
+}
+
+function persistDesktopSettings(settings: PersistedDesktopSettings): void {
+  writeJsonFile(DESKTOP_SETTINGS_PATH, settings);
+}
+
+function isPersistedDesktopBackendState(value: unknown): value is PersistedDesktopBackendState {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { port?: unknown }).port === "number" &&
+    Number.isInteger((value as { port: number }).port) &&
+    (value as { port: number }).port > 0 &&
+    typeof (value as { authToken?: unknown }).authToken === "string" &&
+    (value as { authToken: string }).authToken.trim().length > 0 &&
+    (typeof (value as { pid?: unknown }).pid === "number" ||
+      (value as { pid?: unknown }).pid === null) &&
+    typeof (value as { startedAt?: unknown }).startedAt === "string"
+  );
+}
+
+function readPersistedBackendState(): PersistedDesktopBackendState | null {
+  try {
+    const parsed = readJsonFile(DESKTOP_BACKEND_STATE_PATH);
+    return isPersistedDesktopBackendState(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function persistBackendState(state: PersistedDesktopBackendState): void {
+  writeJsonFile(DESKTOP_BACKEND_STATE_PATH, state);
+}
+
+function clearPersistedBackendState(): void {
+  deleteFileIfExists(DESKTOP_BACKEND_STATE_PATH);
+}
+
+function setBackendConnection(port: number, authToken: string): void {
+  backendPort = port;
+  backendAuthToken = authToken;
+  backendWsUrl = `ws://127.0.0.1:${backendPort}/?token=${encodeURIComponent(backendAuthToken)}`;
+  process.env.T3CODE_DESKTOP_WS_URL = backendWsUrl;
+}
+
+function getBackendControlUrl(port: number): string {
+  return `http://127.0.0.1:${port}${DESKTOP_BACKEND_RUNTIME_PATH}`;
+}
+
+function getBackendControlHeaders(authToken: string): Record<string, string> {
+  return authToken
+    ? {
+        "X-T3Code-Auth-Token": authToken,
+      }
+    : {};
+}
 
 function logTimestamp(): string {
   return new Date().toISOString();
@@ -131,6 +260,74 @@ function formatErrorMessage(error: unknown): string {
     return error.message;
   }
   return String(error);
+}
+
+async function requestBackendControl(
+  input:
+    | { port: number; authToken: string; method: "GET" }
+    | {
+        port: number;
+        authToken: string;
+        method: "POST";
+        action: DesktopBackendControlAction;
+      },
+): Promise<{ ok: boolean; status: number; body: unknown }> {
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => abortController.abort(), 3_000);
+  timeout.unref();
+
+  try {
+    const response = await fetch(getBackendControlUrl(input.port), {
+      method: input.method,
+      headers: {
+        Accept: "application/json",
+        ...getBackendControlHeaders(input.authToken),
+        ...(input.method === "POST" ? { "Content-Type": "application/json" } : {}),
+      },
+      ...(input.method === "POST" ? { body: JSON.stringify({ action: input.action }) } : {}),
+      signal: abortController.signal,
+    });
+
+    const text = await response.text();
+    let body: unknown = null;
+    if (text.trim().length > 0) {
+      try {
+        body = JSON.parse(text) as unknown;
+      } catch {
+        body = text;
+      }
+    }
+
+    return {
+      ok: response.ok,
+      status: response.status,
+      body,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function probePersistedBackend(state: PersistedDesktopBackendState): Promise<boolean> {
+  try {
+    const response = await requestBackendControl({
+      port: state.port,
+      authToken: state.authToken,
+      method: "GET",
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+function tryKillPersistedBackendProcess(pid: number | null): void {
+  if (pid === null) return;
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    // Ignore failures when the persisted PID is already gone.
+  }
 }
 
 function getSafeExternalUrl(rawUrl: unknown): string | null {
@@ -444,6 +641,7 @@ function handleFatalStartupError(stage: string, error: unknown): void {
   }
   stopBackend();
   restoreStdIoCapture?.();
+  quitPrepared = true;
   app.quit();
 }
 
@@ -798,11 +996,13 @@ async function installDownloadedUpdate(): Promise<{ accepted: boolean; completed
   clearUpdatePollTimer();
   try {
     await stopBackendAndWaitForExit();
+    quitPrepared = true;
     autoUpdater.quitAndInstall();
     return { accepted: true, completed: true };
   } catch (error: unknown) {
     const message = formatErrorMessage(error);
     isQuitting = false;
+    quitPrepared = false;
     setUpdateState(reduceDesktopUpdateStateOnInstallFailure(updateState, message));
     console.error(`[desktop-updater] Failed to install update: ${message}`);
     return { accepted: true, completed: false };
@@ -929,6 +1129,40 @@ function backendEnv(): NodeJS.ProcessEnv {
   };
 }
 
+async function adoptPersistedBackendIfAvailable(): Promise<boolean> {
+  const persisted = readPersistedBackendState();
+  if (!persisted) {
+    return false;
+  }
+
+  const healthy = await probePersistedBackend(persisted);
+  if (!healthy) {
+    writeDesktopLogHeader(
+      `discarding stale backend state pid=${persisted.pid ?? "unknown"} port=${persisted.port}`,
+    );
+    clearPersistedBackendState();
+    return false;
+  }
+
+  setBackendConnection(persisted.port, persisted.authToken);
+  writeDesktopLogHeader(
+    `adopted existing backend pid=${persisted.pid ?? "unknown"} port=${persisted.port}`,
+  );
+  return true;
+}
+
+async function reserveNewBackendConnection(): Promise<void> {
+  const port = await Effect.service(NetService).pipe(
+    Effect.flatMap((net) => net.reserveLoopbackPort()),
+    Effect.provide(NetService.layer),
+    Effect.runPromise,
+  );
+  const authToken = Crypto.randomBytes(24).toString("hex");
+  setBackendConnection(port, authToken);
+  writeDesktopLogHeader(`reserved backend port via NetService port=${backendPort}`);
+  writeDesktopLogHeader(`bootstrap resolved websocket url=${backendWsUrl}`);
+}
+
 function scheduleBackendRestart(reason: string): void {
   if (isQuitting || restartTimer) return;
 
@@ -960,9 +1194,16 @@ function startBackend(): void {
       ...backendEnv(),
       ELECTRON_RUN_AS_NODE: "1",
     },
+    detached: true,
     stdio: captureBackendLogs ? ["ignore", "pipe", "pipe"] : "inherit",
   });
   backendProcess = child;
+  persistBackendState({
+    port: backendPort,
+    authToken: backendAuthToken,
+    pid: child.pid ?? null,
+    startedAt: new Date().toISOString(),
+  });
   let backendSessionClosed = false;
   const closeBackendSession = (details: string) => {
     if (backendSessionClosed) return;
@@ -983,6 +1224,7 @@ function startBackend(): void {
     if (backendProcess === child) {
       backendProcess = null;
     }
+    clearPersistedBackendState();
     closeBackendSession(`pid=${child.pid ?? "unknown"} error=${error.message}`);
     scheduleBackendRestart(error.message);
   });
@@ -991,6 +1233,7 @@ function startBackend(): void {
     if (backendProcess === child) {
       backendProcess = null;
     }
+    clearPersistedBackendState();
     closeBackendSession(
       `pid=${child.pid ?? "unknown"} code=${code ?? "null"} signal=${signal ?? "null"}`,
     );
@@ -1008,6 +1251,7 @@ function stopBackend(): void {
 
   const child = backendProcess;
   backendProcess = null;
+  clearPersistedBackendState();
   if (!child) return;
 
   if (child.exitCode === null && child.signalCode === null) {
@@ -1028,6 +1272,7 @@ async function stopBackendAndWaitForExit(timeoutMs = 5_000): Promise<void> {
 
   const child = backendProcess;
   backendProcess = null;
+  clearPersistedBackendState();
   if (!child) return;
   const backendChild = child;
   if (backendChild.exitCode !== null || backendChild.signalCode !== null) return;
@@ -1071,6 +1316,98 @@ async function stopBackendAndWaitForExit(timeoutMs = 5_000): Promise<void> {
   });
 }
 
+function releaseBackendForBackgroundRun(): void {
+  if (restartTimer) {
+    clearTimeout(restartTimer);
+    restartTimer = null;
+  }
+
+  const child = backendProcess;
+  backendProcess = null;
+  if (!child) {
+    return;
+  }
+
+  child.removeAllListeners("error");
+  child.removeAllListeners("exit");
+  child.stdout?.removeAllListeners("data");
+  child.stderr?.removeAllListeners("data");
+  child.stdout?.destroy();
+  child.stderr?.destroy();
+  child.unref();
+}
+
+async function stopLocalBackendSessions(): Promise<void> {
+  if (backendPort <= 0 || backendAuthToken.length === 0) {
+    return;
+  }
+  const response = await requestBackendControl({
+    port: backendPort,
+    authToken: backendAuthToken,
+    method: "POST",
+    action: "stop-local-sessions",
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to stop local backend sessions (status ${response.status}).`);
+  }
+}
+
+async function shutdownDetachedBackend(): Promise<void> {
+  const persisted = readPersistedBackendState();
+  if (!persisted) {
+    return;
+  }
+
+  try {
+    const response = await requestBackendControl({
+      port: persisted.port,
+      authToken: persisted.authToken,
+      method: "POST",
+      action: "shutdown-server",
+    });
+    if (!response.ok) {
+      tryKillPersistedBackendProcess(persisted.pid);
+    }
+  } catch {
+    tryKillPersistedBackendProcess(persisted.pid);
+  } finally {
+    clearPersistedBackendState();
+  }
+}
+
+async function applyAppCloseBehavior(): Promise<void> {
+  switch (desktopAppCloseBehavior) {
+    case "terminate_all_agents":
+      if (backendProcess) {
+        await stopBackendAndWaitForExit();
+      } else {
+        await shutdownDetachedBackend();
+      }
+      return;
+
+    case "terminate_local_agents_only":
+      try {
+        await stopLocalBackendSessions();
+      } catch (error) {
+        writeDesktopLogHeader(
+          `local-only close behavior failed; falling back to full shutdown message=${formatErrorMessage(error)}`,
+        );
+        if (backendProcess) {
+          await stopBackendAndWaitForExit();
+        } else {
+          await shutdownDetachedBackend();
+        }
+        return;
+      }
+      releaseBackendForBackgroundRun();
+      return;
+
+    case "terminate_no_agents":
+      releaseBackendForBackgroundRun();
+      return;
+  }
+}
+
 function registerIpcHandlers(): void {
   ipcMain.removeHandler(PICK_FOLDER_CHANNEL);
   ipcMain.handle(PICK_FOLDER_CHANNEL, async () => {
@@ -1104,6 +1441,18 @@ function registerIpcHandlers(): void {
     }
 
     nativeTheme.themeSource = theme;
+  });
+
+  ipcMain.removeHandler(APP_CLOSE_BEHAVIOR_SET_CHANNEL);
+  ipcMain.handle(APP_CLOSE_BEHAVIOR_SET_CHANNEL, async (_event, rawBehavior: unknown) => {
+    if (!isDesktopAppCloseBehavior(rawBehavior)) {
+      return;
+    }
+
+    desktopAppCloseBehavior = rawBehavior;
+    persistDesktopSettings({
+      appCloseBehavior: desktopAppCloseBehavior,
+    });
   });
 
   ipcMain.removeHandler(CONTEXT_MENU_CHANNEL);
@@ -1313,31 +1662,56 @@ configureAppIdentity();
 
 async function bootstrap(): Promise<void> {
   writeDesktopLogHeader("bootstrap start");
-  backendPort = await Effect.service(NetService).pipe(
-    Effect.flatMap((net) => net.reserveLoopbackPort()),
-    Effect.provide(NetService.layer),
-    Effect.runPromise,
-  );
-  writeDesktopLogHeader(`reserved backend port via NetService port=${backendPort}`);
-  backendAuthToken = Crypto.randomBytes(24).toString("hex");
-  backendWsUrl = `ws://127.0.0.1:${backendPort}/?token=${encodeURIComponent(backendAuthToken)}`;
-  process.env.T3CODE_DESKTOP_WS_URL = backendWsUrl;
-  writeDesktopLogHeader(`bootstrap resolved websocket url=${backendWsUrl}`);
+  const adoptedExistingBackend = await adoptPersistedBackendIfAvailable();
+  if (!adoptedExistingBackend) {
+    await reserveNewBackendConnection();
+  }
 
   registerIpcHandlers();
   writeDesktopLogHeader("bootstrap ipc handlers registered");
-  startBackend();
-  writeDesktopLogHeader("bootstrap backend start requested");
+  if (!adoptedExistingBackend) {
+    startBackend();
+    writeDesktopLogHeader("bootstrap backend start requested");
+  }
   mainWindow = createWindow();
   writeDesktopLogHeader("bootstrap main window created");
 }
 
-app.on("before-quit", () => {
+async function prepareForQuitAndExit(reason: string): Promise<void> {
+  if (quitPrepared) {
+    return;
+  }
+
   isQuitting = true;
-  writeDesktopLogHeader("before-quit received");
+  writeDesktopLogHeader(`${reason} received closeBehavior=${desktopAppCloseBehavior}`);
   clearUpdatePollTimer();
-  stopBackend();
-  restoreStdIoCapture?.();
+
+  try {
+    await applyAppCloseBehavior();
+  } catch (error) {
+    writeDesktopLogHeader(
+      `quit preparation failed reason=${reason} message=${formatErrorMessage(error)}`,
+    );
+  } finally {
+    restoreStdIoCapture?.();
+    quitPrepared = true;
+    app.quit();
+  }
+}
+
+app.on("before-quit", (event) => {
+  if (quitPrepared) {
+    return;
+  }
+
+  event.preventDefault();
+  if (quitPreparationPromise) {
+    return;
+  }
+
+  quitPreparationPromise = prepareForQuitAndExit("before-quit").finally(() => {
+    quitPreparationPromise = null;
+  });
 });
 
 app
@@ -1370,22 +1744,16 @@ app.on("window-all-closed", () => {
 
 if (process.platform !== "win32") {
   process.on("SIGINT", () => {
-    if (isQuitting) return;
-    isQuitting = true;
-    writeDesktopLogHeader("SIGINT received");
-    clearUpdatePollTimer();
-    stopBackend();
-    restoreStdIoCapture?.();
-    app.quit();
+    if (quitPrepared || quitPreparationPromise) return;
+    quitPreparationPromise = prepareForQuitAndExit("SIGINT").finally(() => {
+      quitPreparationPromise = null;
+    });
   });
 
   process.on("SIGTERM", () => {
-    if (isQuitting) return;
-    isQuitting = true;
-    writeDesktopLogHeader("SIGTERM received");
-    clearUpdatePollTimer();
-    stopBackend();
-    restoreStdIoCapture?.();
-    app.quit();
+    if (quitPrepared || quitPreparationPromise) return;
+    quitPreparationPromise = prepareForQuitAndExit("SIGTERM").finally(() => {
+      quitPreparationPromise = null;
+    });
   });
 }

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -11,6 +11,7 @@ const UPDATE_STATE_CHANNEL = "desktop:update-state";
 const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
 const UPDATE_DOWNLOAD_CHANNEL = "desktop:update-download";
 const UPDATE_INSTALL_CHANNEL = "desktop:update-install";
+const APP_CLOSE_BEHAVIOR_SET_CHANNEL = "desktop:app-close-behavior:set";
 const wsUrl = process.env.T3CODE_DESKTOP_WS_URL ?? null;
 
 contextBridge.exposeInMainWorld("desktopBridge", {
@@ -18,6 +19,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   pickFolder: () => ipcRenderer.invoke(PICK_FOLDER_CHANNEL),
   confirm: (message) => ipcRenderer.invoke(CONFIRM_CHANNEL, message),
   setTheme: (theme) => ipcRenderer.invoke(SET_THEME_CHANNEL, theme),
+  setAppCloseBehavior: (behavior) => ipcRenderer.invoke(APP_CLOSE_BEHAVIOR_SET_CHANNEL, behavior),
   showContextMenu: (items, position) => ipcRenderer.invoke(CONTEXT_MENU_CHANNEL, items, position),
   openExternal: (url: string) => ipcRenderer.invoke(OPEN_EXTERNAL_CHANNEL, url),
   onMenuAction: (listener) => {

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -316,6 +316,48 @@ function formatRouteFailureMessage(cause: Cause.Cause<unknown>): string {
   return Cause.pretty(cause);
 }
 
+function hasAuthorizedDesktopRequest(
+  req: http.IncomingMessage,
+  authToken: string | undefined,
+): boolean {
+  if (!authToken) {
+    return true;
+  }
+
+  const rawHeader = req.headers["x-t3code-auth-token"];
+  const providedToken = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
+  return providedToken === authToken;
+}
+
+function readJsonRequestBody(req: http.IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    const maxBytes = 16 * 1024;
+
+    req.on("data", (chunk) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      totalBytes += buffer.byteLength;
+      if (totalBytes > maxBytes) {
+        reject(new Error("Request body too large."));
+        return;
+      }
+      chunks.push(buffer);
+    });
+
+    req.on("end", () => {
+      try {
+        const text = Buffer.concat(chunks).toString("utf8").trim();
+        resolve(text.length > 0 ? (JSON.parse(text) as unknown) : null);
+      } catch (error) {
+        reject(error);
+      }
+    });
+
+    req.on("error", reject);
+  });
+}
+
 export const createServer = Effect.fn(function* (): Effect.fn.Return<
   http.Server,
   ServerLifecycleError,
@@ -520,10 +562,93 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
       res.writeHead(statusCode, headers);
       res.end(body);
     };
+    const respondJson = (statusCode: number, body: unknown) =>
+      respond(statusCode, { "Content-Type": "application/json" }, JSON.stringify(body));
 
     void Effect.runPromise(
       Effect.gen(function* () {
         const url = new URL(req.url ?? "/", `http://localhost:${port}`);
+        if (url.pathname === "/api/desktop/runtime") {
+          if (!hasAuthorizedDesktopRequest(req, authToken)) {
+            respondJson(401, { ok: false, error: "Unauthorized" });
+            return;
+          }
+
+          if (req.method === "GET") {
+            respondJson(200, {
+              ok: true,
+              mode: serverConfig.mode,
+              pid: process.pid,
+            });
+            return;
+          }
+
+          if (req.method === "POST") {
+            const bodyExit = yield* Effect.promise(() => readJsonRequestBody(req)).pipe(
+              Effect.exit,
+            );
+            if (Exit.isFailure(bodyExit)) {
+              respondJson(400, { ok: false, error: "Invalid JSON body" });
+              return;
+            }
+            const body = bodyExit.value;
+
+            const action =
+              typeof body === "object" && body !== null && "action" in body
+                ? (body as { action?: unknown }).action
+                : undefined;
+
+            if (action === "stop-local-sessions") {
+              const snapshot = yield* projectionReadModelQuery.getSnapshot();
+              const projectsById = new Map(
+                snapshot.projects.map((project) => [project.id, project]),
+              );
+              const localThreadIds = snapshot.threads
+                .filter((thread) => {
+                  if (thread.deletedAt !== null || thread.session === null) {
+                    return false;
+                  }
+                  if (thread.session.status === "stopped") {
+                    return false;
+                  }
+                  const project = projectsById.get(thread.projectId);
+                  return project?.deletedAt === null && project.remote == null;
+                })
+                .map((thread) => thread.id);
+
+              const createdAt = new Date().toISOString();
+              yield* Effect.forEach(localThreadIds, (threadId) =>
+                orchestrationEngine.dispatch({
+                  type: "thread.session.stop",
+                  commandId: CommandId.makeUnsafe(crypto.randomUUID()),
+                  threadId,
+                  createdAt,
+                }),
+              ).pipe(Effect.asVoid);
+
+              respondJson(200, {
+                ok: true,
+                stoppedThreadIds: localThreadIds,
+              });
+              return;
+            }
+
+            if (action === "shutdown-server") {
+              respondJson(200, { ok: true, shuttingDown: true });
+              setImmediate(() => {
+                process.kill(process.pid, "SIGTERM");
+              });
+              return;
+            }
+
+            respondJson(400, { ok: false, error: "Unsupported action" });
+            return;
+          }
+
+          respondJson(405, { ok: false, error: "Method not allowed" });
+          return;
+        }
+
         const attachmentRequest = parseProjectThreadAttachmentPath(url.pathname);
         const snapshot =
           url.pathname === "/api/project-favicon" || attachmentRequest !== null

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  DEFAULT_DESKTOP_APP_CLOSE_BEHAVIOR,
   DEFAULT_GIT_DEFAULT_ACTION,
   DEFAULT_THREAD_ID_DISPLAY_MODE,
   DEFAULT_TIMESTAMP_FORMAT,
@@ -68,6 +69,12 @@ describe("resolveAppModelSelection", () => {
 describe("timestamp format defaults", () => {
   it("defaults timestamp format to locale", () => {
     expect(DEFAULT_TIMESTAMP_FORMAT).toBe("locale");
+  });
+});
+
+describe("desktop app close behavior defaults", () => {
+  it("defaults desktop app close behavior to terminating all agents", () => {
+    expect(DEFAULT_DESKTOP_APP_CLOSE_BEHAVIOR).toBe("terminate_all_agents");
   });
 });
 

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -1,7 +1,9 @@
 import { useCallback } from "react";
 import { Option, Schema } from "effect";
 import {
+  DESKTOP_APP_CLOSE_BEHAVIOR_OPTIONS,
   TrimmedNonEmptyString,
+  type DesktopAppCloseBehavior,
   type GitRequestSettings,
   type ProviderKind,
 } from "@t3tools/contracts";
@@ -14,6 +16,7 @@ export const MAX_CUSTOM_MODEL_LENGTH = 256;
 export const TIMESTAMP_FORMAT_OPTIONS = ["locale", "12-hour", "24-hour"] as const;
 export type TimestampFormat = (typeof TIMESTAMP_FORMAT_OPTIONS)[number];
 export const DEFAULT_TIMESTAMP_FORMAT: TimestampFormat = "locale";
+export const DEFAULT_DESKTOP_APP_CLOSE_BEHAVIOR: DesktopAppCloseBehavior = "terminate_all_agents";
 export const GIT_DEFAULT_ACTION_OPTIONS = [
   "auto",
   "commit",
@@ -61,6 +64,9 @@ const AppSettingsSchema = Schema.Struct({
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withConstructorDefault(() => Option.some(true))),
   enableAssistantStreaming: Schema.Boolean.pipe(
     Schema.withConstructorDefault(() => Option.some(false)),
+  ),
+  desktopAppCloseBehavior: Schema.Literals(DESKTOP_APP_CLOSE_BEHAVIOR_OPTIONS).pipe(
+    Schema.withConstructorDefault(() => Option.some(DEFAULT_DESKTOP_APP_CLOSE_BEHAVIOR)),
   ),
   threadIdDisplayMode: Schema.Literals(["hidden", "composer", "message"]).pipe(
     Schema.withConstructorDefault(() => Option.some(DEFAULT_THREAD_ID_DISPLAY_MODE)),

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -285,6 +285,7 @@ function buildAppSettings(overrides: Partial<AppSettings> = {}): AppSettings {
     gitHubBinaryPath: "",
     confirmThreadDelete: true,
     enableAssistantStreaming: false,
+    desktopAppCloseBehavior: "terminate_all_agents",
     threadIdDisplayMode: "hidden",
     timestampFormat: "locale",
     customCodexModels: [],

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -328,7 +328,23 @@ function AppSettingsWatcher() {
   const { settings } = useAppSettings();
   const dismissLocalCodexErrors = useStore((store) => store.dismissLocalCodexErrors);
   const previousSettingsSignatureRef = useRef<string | null>(null);
+  const syncedDesktopCloseBehaviorRef = useRef<string | null>(null);
   const settingsSignature = JSON.stringify(settings);
+
+  useEffect(() => {
+    const bridge = window.desktopBridge;
+    if (!bridge) {
+      syncedDesktopCloseBehaviorRef.current = null;
+      return;
+    }
+    if (syncedDesktopCloseBehaviorRef.current === settings.desktopAppCloseBehavior) {
+      return;
+    }
+    syncedDesktopCloseBehaviorRef.current = settings.desktopAppCloseBehavior;
+    void bridge.setAppCloseBehavior(settings.desktopAppCloseBehavior).catch(() => {
+      syncedDesktopCloseBehaviorRef.current = null;
+    });
+  }, [settings.desktopAppCloseBehavior]);
 
   useEffect(() => {
     if (previousSettingsSignatureRef.current === null) {

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -1,9 +1,14 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { type ProviderKind, DEFAULT_GIT_TEXT_GENERATION_MODEL } from "@t3tools/contracts";
+import {
+  DEFAULT_GIT_TEXT_GENERATION_MODEL,
+  type DesktopAppCloseBehavior,
+  type ProviderKind,
+} from "@t3tools/contracts";
 import { getModelOptions, normalizeModelSlug } from "@t3tools/shared/model";
 import {
+  DEFAULT_DESKTOP_APP_CLOSE_BEHAVIOR,
   DEFAULT_GIT_DEFAULT_ACTION,
   GIT_DEFAULT_ACTION_OPTIONS,
   type GitDefaultAction,
@@ -79,6 +84,17 @@ const GIT_DEFAULT_ACTION_LABELS: Record<GitDefaultAction, string> = {
   commit: "Commit",
   commit_push: "Commit and Push",
   commit_push_pr: "Commit Push and PR",
+};
+const DESKTOP_APP_CLOSE_BEHAVIOR_LABELS: Record<DesktopAppCloseBehavior, string> = {
+  terminate_all_agents: "Terminate All Agents",
+  terminate_local_agents_only: "Terminate Local Agents Only",
+  terminate_no_agents: "Terminate No Agents",
+};
+const DESKTOP_APP_CLOSE_BEHAVIOR_DESCRIPTIONS: Record<DesktopAppCloseBehavior, string> = {
+  terminate_all_agents: "Quit the local threads server and stop every active agent session.",
+  terminate_local_agents_only:
+    "Keep the local threads server running, but stop agents for local projects before exit.",
+  terminate_no_agents: "Leave the local threads server and all agent sessions running.",
 };
 const THREAD_ID_DISPLAY_MODE_LABELS: Record<ThreadIdDisplayMode, string> = {
   hidden: "Hidden",
@@ -630,6 +646,69 @@ function SettingsRouteView() {
                     Reset codex overrides
                   </Button>
                 </div>
+
+                {isElectron ? (
+                  <div className="space-y-2 rounded-xl border border-border bg-background/50 p-4">
+                    <div className="space-y-1">
+                      <label
+                        htmlFor="desktop-app-close-behavior"
+                        className="block text-xs font-medium text-foreground"
+                      >
+                        App close behavior
+                      </label>
+                      <Select
+                        value={settings.desktopAppCloseBehavior}
+                        onValueChange={(value) => {
+                          if (value === null || !(value in DESKTOP_APP_CLOSE_BEHAVIOR_LABELS)) {
+                            return;
+                          }
+                          updateSettings({
+                            desktopAppCloseBehavior: value as DesktopAppCloseBehavior,
+                          });
+                        }}
+                      >
+                        <SelectTrigger
+                          id="desktop-app-close-behavior"
+                          className="w-full"
+                          aria-label="Desktop app close behavior"
+                        >
+                          <SelectValue>
+                            {DESKTOP_APP_CLOSE_BEHAVIOR_LABELS[settings.desktopAppCloseBehavior]}
+                          </SelectValue>
+                        </SelectTrigger>
+                        <SelectPopup>
+                          {Object.entries(DESKTOP_APP_CLOSE_BEHAVIOR_LABELS).map(
+                            ([value, label]) => (
+                              <SelectItem key={value} value={value}>
+                                {label}
+                              </SelectItem>
+                            ),
+                          )}
+                        </SelectPopup>
+                      </Select>
+                    </div>
+
+                    <p className="text-xs text-muted-foreground">
+                      {DESKTOP_APP_CLOSE_BEHAVIOR_DESCRIPTIONS[settings.desktopAppCloseBehavior]}
+                    </p>
+
+                    {settings.desktopAppCloseBehavior !== DEFAULT_DESKTOP_APP_CLOSE_BEHAVIOR ? (
+                      <div className="flex justify-end">
+                        <Button
+                          size="xs"
+                          variant="outline"
+                          onClick={() =>
+                            updateSettings({
+                              desktopAppCloseBehavior: DEFAULT_DESKTOP_APP_CLOSE_BEHAVIOR,
+                            })
+                          }
+                        >
+                          Restore default
+                        </Button>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
               </div>
             </section>
 

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -72,6 +72,12 @@ export type DesktopUpdateStatus =
 
 export type DesktopRuntimeArch = "arm64" | "x64" | "other";
 export type DesktopTheme = "light" | "dark" | "system";
+export const DESKTOP_APP_CLOSE_BEHAVIOR_OPTIONS = [
+  "terminate_all_agents",
+  "terminate_local_agents_only",
+  "terminate_no_agents",
+] as const;
+export type DesktopAppCloseBehavior = (typeof DESKTOP_APP_CLOSE_BEHAVIOR_OPTIONS)[number];
 
 export interface DesktopRuntimeInfo {
   hostArch: DesktopRuntimeArch;
@@ -106,6 +112,7 @@ export interface DesktopBridge {
   pickFolder: () => Promise<string | null>;
   confirm: (message: string) => Promise<boolean>;
   setTheme: (theme: DesktopTheme) => Promise<void>;
+  setAppCloseBehavior: (behavior: DesktopAppCloseBehavior) => Promise<void>;
   showContextMenu: <T extends string>(
     items: readonly ContextMenuItem<T>[],
     position?: { x: number; y: number },


### PR DESCRIPTION
- Persist app close behavior in settings and sync it to Electron
- Add backend shutdown paths for terminating all, local only, or no agents
- Expose the new setting in the desktop settings UI

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
