### PR TITLE
feat(orchestration): reconcile disconnected startup threads

### DIFF
--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -50,6 +50,7 @@ import { RuntimeReceiptBusLive } from "../src/orchestration/Layers/RuntimeReceip
 import { OrchestrationReactorLive } from "../src/orchestration/Layers/OrchestrationReactor.ts";
 import { ProviderCommandReactorLive } from "../src/orchestration/Layers/ProviderCommandReactor.ts";
 import { ProviderRuntimeIngestionLive } from "../src/orchestration/Layers/ProviderRuntimeIngestion.ts";
+import { StartupThreadReconcilerLive } from "../src/orchestration/Layers/StartupThreadReconciler.ts";
 import {
   OrchestrationEngineService,
   type OrchestrationEngineShape,
@@ -308,6 +309,9 @@ export const makeOrchestrationIntegrationHarness = (
       Layer.provideMerge(runtimeIngestionLayer),
       Layer.provideMerge(providerCommandReactorLayer),
       Layer.provideMerge(checkpointReactorLayer),
+      Layer.provideMerge(
+        StartupThreadReconcilerLive.pipe(Layer.provideMerge(runtimeServicesLayer)),
+      ),
     );
     const layer = orchestrationReactorLayer.pipe(
       Layer.provide(persistenceLayer),

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -92,6 +92,7 @@ function createProviderServiceHarness(
     listSessions,
     getCapabilities: () => Effect.succeed({ sessionModelSwitch: "in-session" }),
     rollbackConversation,
+    inspectRecoverableThread: () => unsupported(),
     streamEvents: Stream.fromPubSub(runtimeEventPubSub),
   };
 

--- a/apps/server/src/orchestration/Layers/OrchestrationReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationReactor.test.ts
@@ -5,6 +5,7 @@ import { CheckpointReactor } from "../Services/CheckpointReactor.ts";
 import { ProviderCommandReactor } from "../Services/ProviderCommandReactor.ts";
 import { ProviderRuntimeIngestionService } from "../Services/ProviderRuntimeIngestion.ts";
 import { OrchestrationReactor } from "../Services/OrchestrationReactor.ts";
+import { StartupThreadReconciler } from "../Services/StartupThreadReconciler.ts";
 import { makeOrchestrationReactor } from "./OrchestrationReactor.ts";
 
 describe("OrchestrationReactor", () => {
@@ -17,7 +18,7 @@ describe("OrchestrationReactor", () => {
     runtime = null;
   });
 
-  it("starts provider ingestion, provider command, and checkpoint reactors", async () => {
+  it("starts provider ingestion, provider command, checkpoint, and startup reconciliation", async () => {
     const started: string[] = [];
 
     runtime = ManagedRuntime.make(
@@ -46,6 +47,13 @@ describe("OrchestrationReactor", () => {
             drain: Effect.void,
           }),
         ),
+        Layer.provideMerge(
+          Layer.succeed(StartupThreadReconciler, {
+            start: Effect.sync(() => {
+              started.push("startup-thread-reconciler");
+            }),
+          }),
+        ),
       ),
     );
 
@@ -57,6 +65,7 @@ describe("OrchestrationReactor", () => {
       "provider-runtime-ingestion",
       "provider-command-reactor",
       "checkpoint-reactor",
+      "startup-thread-reconciler",
     ]);
 
     await Effect.runPromise(Scope.close(scope, Exit.void));

--- a/apps/server/src/orchestration/Layers/OrchestrationReactor.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationReactor.ts
@@ -7,16 +7,19 @@ import {
 import { CheckpointReactor } from "../Services/CheckpointReactor.ts";
 import { ProviderCommandReactor } from "../Services/ProviderCommandReactor.ts";
 import { ProviderRuntimeIngestionService } from "../Services/ProviderRuntimeIngestion.ts";
+import { StartupThreadReconciler } from "../Services/StartupThreadReconciler.ts";
 
 export const makeOrchestrationReactor = Effect.gen(function* () {
   const providerRuntimeIngestion = yield* ProviderRuntimeIngestionService;
   const providerCommandReactor = yield* ProviderCommandReactor;
   const checkpointReactor = yield* CheckpointReactor;
+  const startupThreadReconciler = yield* StartupThreadReconciler;
 
   const start: OrchestrationReactorShape["start"] = Effect.gen(function* () {
     yield* providerRuntimeIngestion.start;
     yield* providerCommandReactor.start;
     yield* checkpointReactor.start;
+    yield* startupThreadReconciler.start;
   });
 
   return {

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -531,6 +531,7 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
           return;
         }
 
+        case "thread.turn-completed":
         case "thread.turn-diff-completed": {
           const existingRow = yield* projectionThreadRepository.getById({
             threadId: event.payload.threadId,
@@ -924,6 +925,42 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
             requestedAt: event.payload.createdAt,
             startedAt: event.payload.createdAt,
             completedAt: event.payload.createdAt,
+            checkpointTurnCount: null,
+            checkpointRef: null,
+            checkpointStatus: null,
+            checkpointFiles: [],
+            checkpointDiff: null,
+          });
+          return;
+        }
+
+        case "thread.turn-completed": {
+          const existingTurn = yield* projectionTurnRepository.getByTurnId({
+            threadId: event.payload.threadId,
+            turnId: event.payload.turnId,
+          });
+
+          if (Option.isSome(existingTurn)) {
+            yield* projectionTurnRepository.upsertByTurnId({
+              ...existingTurn.value,
+              assistantMessageId: event.payload.assistantMessageId,
+              state: event.payload.state,
+              startedAt: existingTurn.value.startedAt ?? event.payload.completedAt,
+              requestedAt: existingTurn.value.requestedAt ?? event.payload.completedAt,
+              completedAt: event.payload.completedAt,
+            });
+            return;
+          }
+
+          yield* projectionTurnRepository.upsertByTurnId({
+            turnId: event.payload.turnId,
+            threadId: event.payload.threadId,
+            pendingMessageId: null,
+            assistantMessageId: event.payload.assistantMessageId,
+            state: event.payload.state,
+            requestedAt: event.payload.completedAt,
+            startedAt: event.payload.completedAt,
+            completedAt: event.payload.completedAt,
             checkpointTurnCount: null,
             checkpointRef: null,
             checkpointStatus: null,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -198,6 +198,7 @@ describe("ProviderCommandReactor", () => {
           sessionModelSwitch: provider === "codex" ? "in-session" : "in-session",
         }),
       rollbackConversation: () => unsupported(),
+      inspectRecoverableThread: () => unsupported(),
       streamEvents: Stream.fromPubSub(runtimeEventPubSub),
     };
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -74,6 +74,7 @@ function createProviderServiceHarness() {
     listSessions: () => Effect.succeed([...runtimeSessions]),
     getCapabilities: () => Effect.succeed({ sessionModelSwitch: "in-session" }),
     rollbackConversation: () => unsupported(),
+    inspectRecoverableThread: () => unsupported(),
     streamEvents: Stream.fromPubSub(runtimeEventPubSub),
   };
 

--- a/apps/server/src/orchestration/Layers/StartupThreadReconciler.test.ts
+++ b/apps/server/src/orchestration/Layers/StartupThreadReconciler.test.ts
@@ -1,0 +1,340 @@
+import {
+  CommandId,
+  DEFAULT_PROVIDER_INTERACTION_MODE,
+  ProjectId,
+  ThreadId,
+  TurnId,
+  type ProviderSession,
+} from "@t3tools/contracts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { Effect, Exit, Layer, ManagedRuntime, Scope, Stream } from "effect";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ServerConfig } from "../../config.ts";
+import { OrchestrationCommandReceiptRepositoryLive } from "../../persistence/Layers/OrchestrationCommandReceipts.ts";
+import { OrchestrationEventStoreLive } from "../../persistence/Layers/OrchestrationEventStore.ts";
+import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
+import {
+  ProviderService,
+  type ProviderServiceShape,
+} from "../../provider/Services/ProviderService.ts";
+import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
+import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
+import { StartupThreadReconcilerLive } from "./StartupThreadReconciler.ts";
+import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
+import { StartupThreadReconciler } from "../Services/StartupThreadReconciler.ts";
+
+const asProjectId = (value: string): ProjectId => ProjectId.makeUnsafe(value);
+const asThreadId = (value: string): ThreadId => ThreadId.makeUnsafe(value);
+const asTurnId = (value: string): TurnId => TurnId.makeUnsafe(value);
+
+async function waitFor<T>(
+  load: () => Promise<T>,
+  predicate: (value: T) => boolean,
+  timeoutMs = 2_000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  const poll = async (): Promise<T> => {
+    const value = await load();
+    if (predicate(value)) {
+      return value;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error("Timed out waiting for state.");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    return poll();
+  };
+  return poll();
+}
+
+function makeProviderSession(input: {
+  threadId: ThreadId;
+  status?: ProviderSession["status"];
+  activeTurnId?: TurnId | null;
+}): ProviderSession {
+  const now = "2026-03-19T00:00:00.000Z";
+  return {
+    provider: "codex",
+    status: input.status ?? "running",
+    runtimeMode: "full-access",
+    threadId: input.threadId,
+    ...(input.activeTurnId ? { activeTurnId: input.activeTurnId } : {}),
+    resumeCursor: { opaque: `provider-thread:${input.threadId}` },
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function createProviderServiceStub(input: {
+  inspectRecoverableThread: ProviderServiceShape["inspectRecoverableThread"];
+  stopSession?: ProviderServiceShape["stopSession"];
+}): ProviderServiceShape {
+  const unsupported = () => Effect.die(new Error("Unsupported provider call in test")) as never;
+  return {
+    startSession: () => unsupported(),
+    sendTurn: () => unsupported(),
+    interruptTurn: () => unsupported(),
+    respondToRequest: () => unsupported(),
+    respondToUserInput: () => unsupported(),
+    stopSession: input.stopSession ?? (() => Effect.void),
+    listSessions: () => Effect.succeed([]),
+    getCapabilities: () => Effect.succeed({ sessionModelSwitch: "in-session" }),
+    rollbackConversation: () => unsupported(),
+    inspectRecoverableThread: input.inspectRecoverableThread,
+    streamEvents: Stream.empty,
+  };
+}
+
+describe("StartupThreadReconciler", () => {
+  let runtime: ManagedRuntime.ManagedRuntime<
+    OrchestrationEngineService | StartupThreadReconciler,
+    unknown
+  > | null = null;
+  let scope: Scope.Closeable | null = null;
+
+  afterEach(async () => {
+    if (scope) {
+      await Effect.runPromise(Scope.close(scope, Exit.void));
+    }
+    scope = null;
+    if (runtime) {
+      await runtime.dispose();
+    }
+    runtime = null;
+  });
+
+  async function createHarness(input: {
+    inspectRecoverableThread: ProviderServiceShape["inspectRecoverableThread"];
+    stopSession?: ProviderServiceShape["stopSession"];
+  }) {
+    const orchestrationLayer = OrchestrationEngineLive.pipe(
+      Layer.provide(OrchestrationProjectionPipelineLive),
+      Layer.provide(OrchestrationEventStoreLive),
+      Layer.provide(OrchestrationCommandReceiptRepositoryLive),
+      Layer.provide(SqlitePersistenceMemory),
+    );
+    const providerLayer = Layer.succeed(
+      ProviderService,
+      createProviderServiceStub({
+        inspectRecoverableThread: input.inspectRecoverableThread,
+        ...(input.stopSession ? { stopSession: input.stopSession } : {}),
+      }),
+    );
+    const orchestrationRuntimeLayer = orchestrationLayer.pipe(
+      Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+      Layer.provideMerge(NodeServices.layer),
+    );
+    const startupLayer = StartupThreadReconcilerLive.pipe(
+      Layer.provideMerge(orchestrationRuntimeLayer),
+      Layer.provideMerge(providerLayer),
+    );
+    runtime = ManagedRuntime.make(
+      Layer.mergeAll(orchestrationRuntimeLayer, providerLayer, startupLayer),
+    );
+
+    const engine = await runtime.runPromise(Effect.service(OrchestrationEngineService));
+    const reconciler = await runtime.runPromise(Effect.service(StartupThreadReconciler));
+    scope = await Effect.runPromise(Scope.make("sequential"));
+
+    const createdAt = "2026-03-19T00:00:00.000Z";
+    await Effect.runPromise(
+      engine.dispatch({
+        type: "project.create",
+        commandId: CommandId.makeUnsafe("cmd-project-create"),
+        projectId: asProjectId("project-1"),
+        title: "Project",
+        workspaceRoot: "/tmp/project",
+        defaultModel: "gpt-5-codex",
+        createdAt,
+      }),
+    );
+    await Effect.runPromise(
+      engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.makeUnsafe("cmd-thread-create"),
+        threadId: asThreadId("thread-1"),
+        projectId: asProjectId("project-1"),
+        title: "Thread",
+        model: "gpt-5-codex",
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "full-access",
+        branch: null,
+        worktreePath: null,
+        createdAt,
+      }),
+    );
+
+    return {
+      engine,
+      reconciler,
+    };
+  }
+
+  it("marks stale running threads disconnected before probing, then returns them to working", async () => {
+    const inspectRecoverableThread = vi.fn<ProviderServiceShape["inspectRecoverableThread"]>(
+      ({ threadId }) =>
+        Effect.sleep("100 millis").pipe(
+          Effect.as({
+            session: makeProviderSession({
+              threadId,
+              activeTurnId: asTurnId("turn-1"),
+            }),
+            threadSnapshot: {
+              threadId,
+              turns: [],
+            },
+            recovered: true,
+          }),
+        ),
+    );
+    const { engine, reconciler } = await createHarness({ inspectRecoverableThread });
+    const startedAt = "2026-03-19T00:00:05.000Z";
+
+    await Effect.runPromise(
+      engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-running"),
+        threadId: asThreadId("thread-1"),
+        session: {
+          threadId: asThreadId("thread-1"),
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "full-access",
+          activeTurnId: asTurnId("turn-1"),
+          lastError: null,
+          updatedAt: startedAt,
+        },
+        createdAt: startedAt,
+      }),
+    );
+
+    await Effect.runPromise(reconciler.start.pipe(Scope.provide(scope!)));
+
+    const disconnectedThread = await waitFor(
+      async () => {
+        const readModel = await Effect.runPromise(engine.getReadModel());
+        return readModel.threads.find((entry) => entry.id === asThreadId("thread-1")) ?? null;
+      },
+      (thread) => thread?.session?.status === "disconnected",
+    );
+    expect(disconnectedThread?.session?.status).toBe("disconnected");
+
+    const runningThread = await waitFor(
+      async () => {
+        const readModel = await Effect.runPromise(engine.getReadModel());
+        return readModel.threads.find((entry) => entry.id === asThreadId("thread-1")) ?? null;
+      },
+      (thread) => thread?.session?.status === "running",
+    );
+    expect(runningThread?.session?.activeTurnId).toBe(asTurnId("turn-1"));
+    expect(inspectRecoverableThread).toHaveBeenCalledTimes(1);
+  });
+
+  it("synthesizes completion for stale running threads that finished while t3 was away", async () => {
+    const stopSession = vi.fn<ProviderServiceShape["stopSession"]>(() => Effect.void);
+    const { engine, reconciler } = await createHarness({
+      inspectRecoverableThread: ({ threadId }) =>
+        Effect.succeed({
+          session: makeProviderSession({
+            threadId,
+            status: "ready",
+            activeTurnId: null,
+          }),
+          threadSnapshot: {
+            threadId,
+            turns: [],
+          },
+          recovered: true,
+        }),
+      stopSession,
+    });
+    const startedAt = "2026-03-19T00:00:05.000Z";
+
+    await Effect.runPromise(
+      engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-running"),
+        threadId: asThreadId("thread-1"),
+        session: {
+          threadId: asThreadId("thread-1"),
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "full-access",
+          activeTurnId: asTurnId("turn-1"),
+          lastError: null,
+          updatedAt: startedAt,
+        },
+        createdAt: startedAt,
+      }),
+    );
+
+    await Effect.runPromise(reconciler.start.pipe(Scope.provide(scope!)));
+
+    const completedThread = await waitFor(
+      async () => {
+        const readModel = await Effect.runPromise(engine.getReadModel());
+        return readModel.threads.find((entry) => entry.id === asThreadId("thread-1")) ?? null;
+      },
+      (thread) => {
+        if (thread?.latestTurn?.turnId !== asTurnId("turn-1")) {
+          return false;
+        }
+        return thread.latestTurn.completedAt !== null && thread.session?.status === "stopped";
+      },
+    );
+
+    expect(completedThread?.latestTurn?.state).toBe("completed");
+    expect(completedThread?.session?.status).toBe("stopped");
+    expect(stopSession).toHaveBeenCalledWith({ threadId: asThreadId("thread-1") });
+  });
+
+  it("does not downgrade already-completed threads into disconnected recovery", async () => {
+    const inspectRecoverableThread = vi.fn<ProviderServiceShape["inspectRecoverableThread"]>(
+      () =>
+        Effect.die(
+          new Error("inspectRecoverableThread should not run for already completed threads"),
+        ) as never,
+    );
+    const { engine, reconciler } = await createHarness({ inspectRecoverableThread });
+    const completedAt = "2026-03-19T00:00:10.000Z";
+
+    await Effect.runPromise(
+      engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-ready"),
+        threadId: asThreadId("thread-1"),
+        session: {
+          threadId: asThreadId("thread-1"),
+          status: "ready",
+          providerName: "codex",
+          runtimeMode: "full-access",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: completedAt,
+        },
+        createdAt: completedAt,
+      }),
+    );
+    await Effect.runPromise(
+      engine.dispatch({
+        type: "thread.turn.complete",
+        commandId: CommandId.makeUnsafe("cmd-turn-complete"),
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-1"),
+        state: "completed",
+        completedAt,
+        createdAt: completedAt,
+      }),
+    );
+
+    await Effect.runPromise(reconciler.start.pipe(Scope.provide(scope!)));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const readModel = await Effect.runPromise(engine.getReadModel());
+    const thread = readModel.threads.find((entry) => entry.id === asThreadId("thread-1"));
+    expect(thread?.session?.status).toBe("ready");
+    expect(thread?.latestTurn?.completedAt).toBe(completedAt);
+    expect(inspectRecoverableThread).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/orchestration/Layers/StartupThreadReconciler.ts
+++ b/apps/server/src/orchestration/Layers/StartupThreadReconciler.ts
@@ -1,0 +1,299 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  CommandId,
+  type OrchestrationSession,
+  type OrchestrationThread,
+  type ProviderSession,
+  ThreadId,
+  type TurnId,
+} from "@t3tools/contracts";
+import { Effect, Layer, Option } from "effect";
+
+import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
+import {
+  StartupThreadReconciler,
+  type StartupThreadReconcilerShape,
+} from "../Services/StartupThreadReconciler.ts";
+import { ProviderService } from "../../provider/Services/ProviderService.ts";
+import { readProviderThreadIdFromResumeCursor } from "../../provider/remoteSessionMetadata.ts";
+
+const RECONCILE_TIMEOUT_MS = 15_000;
+const RECONCILE_CONCURRENCY = 4;
+
+function readRequestId(activity: OrchestrationThread["activities"][number]): string | null {
+  const payload = activity.payload;
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+  const requestId = (payload as { requestId?: unknown }).requestId;
+  return typeof requestId === "string" ? requestId : null;
+}
+
+function hasPendingApproval(thread: OrchestrationThread): boolean {
+  const open = new Set<string>();
+  for (const activity of thread.activities) {
+    const requestId = readRequestId(activity);
+    if (!requestId) {
+      continue;
+    }
+    if (activity.kind === "approval.requested") {
+      open.add(requestId);
+      continue;
+    }
+    if (activity.kind === "approval.resolved") {
+      open.delete(requestId);
+      continue;
+    }
+    if (
+      activity.kind === "provider.approval.respond.failed" &&
+      typeof activity.payload === "object" &&
+      activity.payload !== null &&
+      "detail" in activity.payload &&
+      typeof (activity.payload as { detail?: unknown }).detail === "string" &&
+      (activity.payload as { detail: string }).detail.includes("Unknown pending permission request")
+    ) {
+      open.delete(requestId);
+    }
+  }
+  return open.size > 0;
+}
+
+function hasPendingUserInput(thread: OrchestrationThread): boolean {
+  const open = new Set<string>();
+  for (const activity of thread.activities) {
+    const requestId = readRequestId(activity);
+    if (!requestId) {
+      continue;
+    }
+    if (activity.kind === "user-input.requested") {
+      open.add(requestId);
+      continue;
+    }
+    if (activity.kind === "user-input.resolved") {
+      open.delete(requestId);
+    }
+  }
+  return open.size > 0;
+}
+
+function toSessionFromThread(input: {
+  readonly thread: OrchestrationThread;
+  readonly status: OrchestrationSession["status"];
+  readonly now: string;
+}): OrchestrationSession | null {
+  const existing = input.thread.session;
+  if (!existing) {
+    return null;
+  }
+  return {
+    ...existing,
+    status: input.status,
+    updatedAt: input.now,
+  };
+}
+
+function toSessionFromProvider(input: {
+  readonly thread: OrchestrationThread;
+  readonly providerSession: ProviderSession;
+  readonly status: OrchestrationSession["status"];
+  readonly activeTurnId: TurnId | null;
+  readonly now: string;
+}): OrchestrationSession | null {
+  const existing = input.thread.session;
+  if (!existing) {
+    return null;
+  }
+  return {
+    threadId: input.thread.id,
+    status: input.status,
+    providerName: input.providerSession.provider,
+    runtimeMode: input.providerSession.runtimeMode,
+    activeTurnId: input.activeTurnId,
+    lastError: input.providerSession.lastError ?? null,
+    ...(readProviderThreadIdFromResumeCursor(input.providerSession.resumeCursor)
+      ? {
+          providerThreadId: readProviderThreadIdFromResumeCursor(
+            input.providerSession.resumeCursor,
+          ),
+        }
+      : existing.providerThreadId
+        ? { providerThreadId: existing.providerThreadId }
+        : {}),
+    ...(input.providerSession.resumeCursor !== undefined
+      ? { resumeAvailable: true }
+      : existing.resumeAvailable !== undefined
+        ? { resumeAvailable: existing.resumeAvailable }
+        : {}),
+    ...(existing.reconnectState !== undefined ? { reconnectState: existing.reconnectState } : {}),
+    ...(existing.reconnectSummary !== undefined
+      ? { reconnectSummary: existing.reconnectSummary }
+      : {}),
+    ...(existing.reconnectUpdatedAt !== undefined
+      ? { reconnectUpdatedAt: existing.reconnectUpdatedAt }
+      : {}),
+    updatedAt: input.now,
+  };
+}
+
+const make = Effect.gen(function* () {
+  const orchestrationEngine = yield* OrchestrationEngineService;
+  const providerService = yield* ProviderService;
+
+  const setThreadSession = (thread: OrchestrationThread, status: OrchestrationSession["status"]) =>
+    Effect.gen(function* () {
+      const now = new Date().toISOString();
+      const session = toSessionFromThread({ thread, status, now });
+      if (!session) {
+        return;
+      }
+      yield* orchestrationEngine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe(randomUUID()),
+        threadId: thread.id,
+        session,
+        createdAt: now,
+      });
+    });
+
+  const stopRecoveredSession = (threadId: ThreadId) =>
+    providerService.stopSession({ threadId }).pipe(Effect.ignore);
+
+  const reconcileThread = (threadId: ThreadId) =>
+    Effect.gen(function* () {
+      const readModel = yield* orchestrationEngine.getReadModel();
+      const thread = readModel.threads.find((entry) => entry.id === threadId);
+      if (!thread || thread.deletedAt !== null) {
+        return;
+      }
+      if (thread.session?.status !== "disconnected") {
+        return;
+      }
+      if (thread.latestTurn?.completedAt !== null) {
+        return;
+      }
+
+      yield* setThreadSession(thread, "starting");
+
+      const inspectedExit = yield* Effect.exit(
+        providerService
+          .inspectRecoverableThread({ threadId })
+          .pipe(Effect.timeoutOption(RECONCILE_TIMEOUT_MS)),
+      );
+      if (inspectedExit._tag === "Failure") {
+        yield* setThreadSession(thread, "disconnected");
+        yield* stopRecoveredSession(thread.id);
+        return;
+      }
+      const inspected = Option.getOrUndefined(inspectedExit.value);
+
+      if (!inspected) {
+        yield* setThreadSession(thread, "disconnected");
+        yield* stopRecoveredSession(thread.id);
+        return;
+      }
+
+      const refreshedReadModel = yield* orchestrationEngine.getReadModel();
+      const refreshedThread = refreshedReadModel.threads.find((entry) => entry.id === threadId);
+      if (!refreshedThread || refreshedThread.deletedAt !== null) {
+        yield* stopRecoveredSession(thread.id);
+        return;
+      }
+
+      const now = new Date().toISOString();
+      if (hasPendingApproval(refreshedThread) || hasPendingUserInput(refreshedThread)) {
+        const session = toSessionFromProvider({
+          thread: refreshedThread,
+          providerSession: inspected.session,
+          status: "ready",
+          activeTurnId: null,
+          now,
+        });
+        if (session) {
+          yield* orchestrationEngine.dispatch({
+            type: "thread.session.set",
+            commandId: CommandId.makeUnsafe(randomUUID()),
+            threadId,
+            session,
+            createdAt: now,
+          });
+        }
+        return;
+      }
+
+      if (inspected.session.activeTurnId) {
+        const session = toSessionFromProvider({
+          thread: refreshedThread,
+          providerSession: inspected.session,
+          status: "running",
+          activeTurnId: inspected.session.activeTurnId,
+          now,
+        });
+        if (session) {
+          yield* orchestrationEngine.dispatch({
+            type: "thread.session.set",
+            commandId: CommandId.makeUnsafe(randomUUID()),
+            threadId,
+            session,
+            createdAt: now,
+          });
+        }
+        return;
+      }
+
+      if (refreshedThread.latestTurn?.turnId) {
+        yield* orchestrationEngine.dispatch({
+          type: "thread.turn.complete",
+          commandId: CommandId.makeUnsafe(randomUUID()),
+          threadId,
+          turnId: refreshedThread.latestTurn.turnId,
+          state: "completed",
+          completedAt: now,
+          ...(refreshedThread.latestTurn.assistantMessageId
+            ? { assistantMessageId: refreshedThread.latestTurn.assistantMessageId }
+            : {}),
+          createdAt: now,
+        });
+      }
+
+      yield* stopRecoveredSession(thread.id);
+      yield* setThreadSession(refreshedThread, "stopped");
+    });
+
+  const runInitialReconciliation = Effect.gen(function* () {
+    const readModel = yield* orchestrationEngine.getReadModel();
+    const candidateIds = readModel.threads
+      .filter((thread) => thread.deletedAt === null)
+      .filter((thread) => thread.session?.status === "running")
+      .filter((thread) => thread.latestTurn?.completedAt === null)
+      .filter((thread) => !hasPendingApproval(thread))
+      .filter((thread) => !hasPendingUserInput(thread))
+      .map((thread) => thread.id);
+
+    yield* Effect.forEach(
+      candidateIds,
+      (threadId) => {
+        const currentThread = readModel.threads.find((entry) => entry.id === threadId);
+        if (!currentThread) {
+          return Effect.void;
+        }
+        return setThreadSession(currentThread, "disconnected");
+      },
+      { concurrency: 1 },
+    );
+
+    yield* Effect.forEach(candidateIds, reconcileThread, {
+      concurrency: RECONCILE_CONCURRENCY,
+    });
+  });
+
+  const start: StartupThreadReconcilerShape["start"] = Effect.forkScoped(
+    runInitialReconciliation.pipe(Effect.ignore),
+  ).pipe(Effect.asVoid);
+
+  return {
+    start,
+  } satisfies StartupThreadReconcilerShape;
+});
+
+export const StartupThreadReconcilerLive = Layer.effect(StartupThreadReconciler, make);

--- a/apps/server/src/orchestration/Schemas.ts
+++ b/apps/server/src/orchestration/Schemas.ts
@@ -10,6 +10,7 @@ import {
   ThreadMessageSentPayload as ContractsThreadMessageSentPayloadSchema,
   ThreadProposedPlanUpsertedPayload as ContractsThreadProposedPlanUpsertedPayloadSchema,
   ThreadSessionSetPayload as ContractsThreadSessionSetPayloadSchema,
+  ThreadTurnCompletedPayload as ContractsThreadTurnCompletedPayloadSchema,
   ThreadTurnDiffCompletedPayload as ContractsThreadTurnDiffCompletedPayloadSchema,
   ThreadRevertedPayload as ContractsThreadRevertedPayloadSchema,
   ThreadActivityAppendedPayload as ContractsThreadActivityAppendedPayloadSchema,
@@ -34,6 +35,7 @@ export const ThreadDeletedPayload = ContractsThreadDeletedPayloadSchema;
 export const MessageSentPayloadSchema = ContractsThreadMessageSentPayloadSchema;
 export const ThreadProposedPlanUpsertedPayload = ContractsThreadProposedPlanUpsertedPayloadSchema;
 export const ThreadSessionSetPayload = ContractsThreadSessionSetPayloadSchema;
+export const ThreadTurnCompletedPayload = ContractsThreadTurnCompletedPayloadSchema;
 export const ThreadTurnDiffCompletedPayload = ContractsThreadTurnDiffCompletedPayloadSchema;
 export const ThreadRevertedPayload = ContractsThreadRevertedPayloadSchema;
 export const ThreadActivityAppendedPayload = ContractsThreadActivityAppendedPayloadSchema;

--- a/apps/server/src/orchestration/Services/StartupThreadReconciler.ts
+++ b/apps/server/src/orchestration/Services/StartupThreadReconciler.ts
@@ -1,0 +1,11 @@
+import { ServiceMap } from "effect";
+import type { Effect, Scope } from "effect";
+
+export interface StartupThreadReconcilerShape {
+  readonly start: Effect.Effect<void, never, Scope.Scope>;
+}
+
+export class StartupThreadReconciler extends ServiceMap.Service<
+  StartupThreadReconciler,
+  StartupThreadReconcilerShape
+>()("t3/orchestration/Services/StartupThreadReconciler") {}

--- a/apps/server/src/orchestration/decider.projectScripts.test.ts
+++ b/apps/server/src/orchestration/decider.projectScripts.test.ts
@@ -358,4 +358,88 @@ describe("decider project scripts", () => {
       },
     });
   });
+
+  it("emits thread.turn-completed from thread.turn.complete", async () => {
+    const now = new Date().toISOString();
+    const initial = createEmptyReadModel(now);
+    const withProject = await Effect.runPromise(
+      projectEvent(initial, {
+        sequence: 1,
+        eventId: asEventId("evt-project-create-turn-complete"),
+        aggregateKind: "project",
+        aggregateId: asProjectId("project-1"),
+        type: "project.created",
+        occurredAt: now,
+        commandId: CommandId.makeUnsafe("cmd-project-create-turn-complete"),
+        causationEventId: null,
+        correlationId: CommandId.makeUnsafe("cmd-project-create-turn-complete"),
+        metadata: {},
+        payload: {
+          projectId: asProjectId("project-1"),
+          title: "Project",
+          workspaceRoot: "/tmp/project",
+          defaultModel: null,
+          scripts: [],
+          createdAt: now,
+          updatedAt: now,
+        },
+      }),
+    );
+    const readModel = await Effect.runPromise(
+      projectEvent(withProject, {
+        sequence: 2,
+        eventId: asEventId("evt-thread-create-turn-complete"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.makeUnsafe("thread-1"),
+        type: "thread.created",
+        occurredAt: now,
+        commandId: CommandId.makeUnsafe("cmd-thread-create-turn-complete"),
+        causationEventId: null,
+        correlationId: CommandId.makeUnsafe("cmd-thread-create-turn-complete"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          projectId: asProjectId("project-1"),
+          title: "Thread",
+          model: "gpt-5-codex",
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "full-access",
+          branch: null,
+          worktreePath: null,
+          createdAt: now,
+          updatedAt: now,
+        },
+      }),
+    );
+
+    const result = await Effect.runPromise(
+      decideOrchestrationCommand({
+        command: {
+          type: "thread.turn.complete",
+          commandId: CommandId.makeUnsafe("cmd-turn-complete"),
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          turnId: "turn-1" as never,
+          state: "completed",
+          completedAt: now,
+          assistantMessageId: "message-1" as never,
+          createdAt: now,
+        },
+        readModel,
+      }),
+    );
+
+    const singleResult = Array.isArray(result) ? null : result;
+    if (singleResult === null) {
+      throw new Error("Expected a single thread.turn-completed event.");
+    }
+    expect(singleResult).toMatchObject({
+      type: "thread.turn-completed",
+      payload: {
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        turnId: "turn-1",
+        state: "completed",
+        assistantMessageId: "message-1",
+      },
+    });
+  });
 });

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -555,6 +555,30 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       };
     }
 
+    case "thread.turn.complete": {
+      yield* requireThread({
+        readModel,
+        command,
+        threadId: command.threadId,
+      });
+      return {
+        ...withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        }),
+        type: "thread.turn-completed",
+        payload: {
+          threadId: command.threadId,
+          turnId: command.turnId,
+          state: command.state,
+          assistantMessageId: command.assistantMessageId ?? null,
+          completedAt: command.completedAt,
+        },
+      };
+    }
+
     case "thread.turn.diff.complete": {
       yield* requireThread({
         readModel,

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -267,6 +267,67 @@ describe("orchestration projector", () => {
     expect(afterUpdate.threads[0]?.updatedAt).toBe(updatedAt);
   });
 
+  it("updates latest turn state from thread.turn-completed", async () => {
+    const now = "2026-02-23T08:00:00.000Z";
+    const completedAt = "2026-02-23T08:03:00.000Z";
+    const model = createEmptyReadModel(now);
+
+    const afterCreate = await Effect.runPromise(
+      projectEvent(
+        model,
+        makeEvent({
+          sequence: 1,
+          type: "thread.created",
+          aggregateKind: "thread",
+          aggregateId: "thread-1",
+          occurredAt: now,
+          commandId: "cmd-create",
+          payload: {
+            threadId: "thread-1",
+            projectId: "project-1",
+            title: "demo",
+            model: "gpt-5.3-codex",
+            runtimeMode: "full-access",
+            branch: null,
+            worktreePath: null,
+            createdAt: now,
+            updatedAt: now,
+          },
+        }),
+      ),
+    );
+
+    const afterComplete = await Effect.runPromise(
+      projectEvent(
+        afterCreate,
+        makeEvent({
+          sequence: 2,
+          type: "thread.turn-completed",
+          aggregateKind: "thread",
+          aggregateId: "thread-1",
+          occurredAt: completedAt,
+          commandId: "cmd-complete",
+          payload: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            state: "completed",
+            assistantMessageId: "message-1",
+            completedAt,
+          },
+        }),
+      ),
+    );
+
+    expect(afterComplete.threads[0]?.latestTurn).toEqual({
+      turnId: "turn-1",
+      state: "completed",
+      requestedAt: completedAt,
+      startedAt: completedAt,
+      completedAt,
+      assistantMessageId: "message-1",
+    });
+  });
+
   it("marks assistant messages completed with non-streaming updates", async () => {
     const createdAt = "2026-02-23T09:00:00.000Z";
     const deltaAt = "2026-02-23T09:00:01.000Z";

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -22,6 +22,7 @@ import {
   ThreadRuntimeModeSetPayload,
   ThreadRevertedPayload,
   ThreadSessionSetPayload,
+  ThreadTurnCompletedPayload,
   ThreadTurnDiffCompletedPayload,
 } from "./Schemas.ts";
 
@@ -469,6 +470,41 @@ export function projectEvent(
           ...nextBase,
           threads: updateThread(nextBase.threads, payload.threadId, {
             proposedPlans,
+            updatedAt: event.occurredAt,
+          }),
+        };
+      });
+
+    case "thread.turn-completed":
+      return Effect.gen(function* () {
+        const payload = yield* decodeForEvent(
+          ThreadTurnCompletedPayload,
+          event.payload,
+          event.type,
+          "payload",
+        );
+        const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+        if (!thread) {
+          return nextBase;
+        }
+
+        return {
+          ...nextBase,
+          threads: updateThread(nextBase.threads, payload.threadId, {
+            latestTurn: {
+              turnId: payload.turnId,
+              state: payload.state,
+              requestedAt:
+                thread.latestTurn?.turnId === payload.turnId
+                  ? thread.latestTurn.requestedAt
+                  : payload.completedAt,
+              startedAt:
+                thread.latestTurn?.turnId === payload.turnId
+                  ? (thread.latestTurn.startedAt ?? payload.completedAt)
+                  : payload.completedAt,
+              completedAt: payload.completedAt,
+              assistantMessageId: payload.assistantMessageId,
+            },
             updatedAt: event.occurredAt,
           }),
         };

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -331,6 +331,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         readonly adapter: ProviderAdapterShape<ProviderAdapterError>;
         readonly threadId: ThreadId;
         readonly isActive: boolean;
+        readonly recovered: boolean;
       },
       ProviderServiceError
     > =>
@@ -347,15 +348,30 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
 
         const hasRequestedSession = yield* adapter.hasSession(input.threadId);
         if (hasRequestedSession) {
-          return { adapter, threadId: input.threadId, isActive: true } as const;
+          return {
+            adapter,
+            threadId: input.threadId,
+            isActive: true,
+            recovered: false,
+          } as const;
         }
 
         if (!input.allowRecovery) {
-          return { adapter, threadId: input.threadId, isActive: false } as const;
+          return {
+            adapter,
+            threadId: input.threadId,
+            isActive: false,
+            recovered: false,
+          } as const;
         }
 
         const recovered = yield* recoverSessionForThread({ binding, operation: input.operation });
-        return { adapter: recovered.adapter, threadId: input.threadId, isActive: true } as const;
+        return {
+          adapter: recovered.adapter,
+          threadId: input.threadId,
+          isActive: true,
+          recovered: true,
+        } as const;
       });
 
     const startSession: ProviderServiceShape["startSession"] = (threadId, rawInput) =>
@@ -566,6 +582,29 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         });
       });
 
+    const inspectRecoverableThread: ProviderServiceShape["inspectRecoverableThread"] = (input) =>
+      Effect.gen(function* () {
+        const routed = yield* resolveRoutableSession({
+          threadId: input.threadId,
+          operation: "ProviderService.inspectRecoverableThread",
+          allowRecovery: true,
+        });
+        const activeSessions = yield* listSessions();
+        const session = activeSessions.find((entry) => entry.threadId === input.threadId);
+        if (!session) {
+          return yield* toValidationError(
+            "ProviderService.inspectRecoverableThread",
+            `Recovered thread '${input.threadId}' has no active provider session.`,
+          );
+        }
+        const threadSnapshot = yield* routed.adapter.readThread(input.threadId);
+        return {
+          session,
+          threadSnapshot,
+          recovered: routed.recovered,
+        } as const;
+      });
+
     const getCapabilities: ProviderServiceShape["getCapabilities"] = (provider) =>
       registry.getByProvider(provider).pipe(Effect.map((adapter) => adapter.capabilities));
 
@@ -634,6 +673,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
       respondToUserInput,
       stopSession,
       listSessions,
+      inspectRecoverableThread,
       getCapabilities,
       rollbackConversation,
       // Each access creates a fresh PubSub subscription so that multiple

--- a/apps/server/src/provider/Services/ProviderService.ts
+++ b/apps/server/src/provider/Services/ProviderService.ts
@@ -28,7 +28,7 @@ import { ServiceMap } from "effect";
 import type { Effect, Stream } from "effect";
 
 import type { ProviderServiceError } from "../Errors.ts";
-import type { ProviderAdapterCapabilities } from "./ProviderAdapter.ts";
+import type { ProviderAdapterCapabilities, ProviderThreadSnapshot } from "./ProviderAdapter.ts";
 
 /**
  * ProviderServiceShape - Service API for provider session and turn orchestration.
@@ -98,6 +98,18 @@ export interface ProviderServiceShape {
     readonly threadId: ThreadId;
     readonly numTurns: number;
   }) => Effect.Effect<void, ProviderServiceError>;
+
+  /**
+   * Recover a persisted session when needed, then inspect the provider thread.
+   */
+  readonly inspectRecoverableThread: (input: { readonly threadId: ThreadId }) => Effect.Effect<
+    {
+      readonly session: ProviderSession;
+      readonly threadSnapshot: ProviderThreadSnapshot;
+      readonly recovered: boolean;
+    },
+    ProviderServiceError
+  >;
 
   /**
    * Canonical provider runtime event stream.

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -19,6 +19,7 @@ import { OrchestrationProjectionPipelineLive } from "./orchestration/Layers/Proj
 import { OrchestrationProjectionSnapshotQueryLive } from "./orchestration/Layers/ProjectionSnapshotQuery";
 import { ProviderRuntimeIngestionLive } from "./orchestration/Layers/ProviderRuntimeIngestion";
 import { RuntimeReceiptBusLive } from "./orchestration/Layers/RuntimeReceiptBus";
+import { StartupThreadReconcilerLive } from "./orchestration/Layers/StartupThreadReconciler";
 import { ProviderUnsupportedError } from "./provider/Errors";
 import { makeCodexAdapterLive } from "./provider/Layers/CodexAdapter";
 import { ProviderAdapterRegistryLive } from "./provider/Layers/ProviderAdapterRegistry";
@@ -107,6 +108,7 @@ export function makeServerRuntimeServicesLayer() {
     Layer.provideMerge(runtimeIngestionLayer),
     Layer.provideMerge(providerCommandReactorLayer),
     Layer.provideMerge(checkpointReactorLayer),
+    Layer.provideMerge(StartupThreadReconcilerLive.pipe(Layer.provideMerge(runtimeServicesLayer))),
   );
 
   const terminalLayer = TerminalManagerLive.pipe(

--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -1518,6 +1518,7 @@ describe("WebSocket Server", () => {
       listSessions: () => Effect.succeed([]),
       getCapabilities: () => Effect.succeed({ sessionModelSwitch: "in-session" }),
       rollbackConversation: () => unsupported(),
+      inspectRecoverableThread: () => unsupported(),
       streamEvents: Stream.fromPubSub(runtimeEventPubSub),
     };
     const providerLayer = Layer.succeed(ProviderService, providerService);

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -83,7 +83,7 @@ describe("resolveVisibleProviderHealthStatus", () => {
     });
   });
 
-  it("shows reconnect metadata for disconnected remote sessions", () => {
+  it("suppresses background reconnect and disconnected remote status banners", () => {
     expect(
       resolveVisibleProviderHealthStatus({
         status: {
@@ -99,8 +99,8 @@ describe("resolveVisibleProviderHealthStatus", () => {
         },
         session: {
           provider: "codex",
-          status: "closed",
-          orchestrationStatus: "stopped",
+          status: "disconnected",
+          orchestrationStatus: "disconnected",
           providerThreadId: "thread_remote_123",
           resumeAvailable: true,
           createdAt: "2026-03-16T00:00:00.000Z",
@@ -108,11 +108,7 @@ describe("resolveVisibleProviderHealthStatus", () => {
         },
         localCodexErrorsDismissedAfter: "2026-03-16T01:00:00.000Z",
       }),
-    ).toMatchObject({
-      kind: "remote",
-      status: "warning",
-      message: "Resume is available for provider thread thread_remote_123.",
-    });
+    ).toBeNull();
   });
 
   it("hides dismissed local Codex provider health until a newer status arrives", () => {

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -1,5 +1,4 @@
 import {
-  type OrchestrationSessionReconnectState,
   ProjectId,
   type ProjectRemoteTarget,
   type ProviderKind,
@@ -221,38 +220,6 @@ function isOlderThanOrEqualToDismissedAt(
   return checkedAtMs <= dismissedAtMs;
 }
 
-function buildRemoteReconnectSummary(input: {
-  reconnectState?: OrchestrationSessionReconnectState | undefined;
-  resumeAvailable?: boolean | undefined;
-  reconnectSummary?: string | undefined;
-  providerThreadId?: string | undefined;
-}): string | null {
-  if (input.reconnectSummary) {
-    return input.reconnectSummary;
-  }
-
-  switch (input.reconnectState) {
-    case "resume-thread":
-      return input.providerThreadId
-        ? `Reconnected to provider thread ${input.providerThreadId}.`
-        : "Reconnected to the persisted remote provider session.";
-    case "adopt-existing":
-      return "Reattached to an existing remote provider session.";
-    case "resume-unavailable":
-      return "Automatic reconnect is not available for this remote session.";
-    case "resume-failed":
-      return "Automatic reconnect failed for this remote session.";
-    case "fresh-start":
-      return null;
-    default:
-      return input.resumeAvailable && input.providerThreadId
-        ? `Resume is available for provider thread ${input.providerThreadId}.`
-        : input.resumeAvailable
-          ? "Automatic reconnect is available for this remote session."
-          : null;
-  }
-}
-
 function buildRemoteProviderHealthStatus(input: {
   projectRemote: ProjectRemoteTarget;
   session: ThreadSession | null;
@@ -275,51 +242,26 @@ function buildRemoteProviderHealthStatus(input: {
     };
   }
 
-  const reconnectSummary = buildRemoteReconnectSummary({
-    reconnectState: session.reconnectState,
-    reconnectSummary: session.reconnectSummary,
-    resumeAvailable: session.resumeAvailable,
-    providerThreadId: session.providerThreadId,
-  });
-
   switch (session.orchestrationStatus) {
-    case "starting":
-      return {
-        kind: "remote",
-        status: "warning",
-        title: "Remote Codex session status",
-        message: reconnectSummary ?? `Connecting to the remote Codex session on ${hostAlias}.`,
-      };
     case "error":
-      return {
-        kind: "remote",
-        status: "error",
-        title: "Remote Codex session status",
-        message:
-          session.lastError ??
-          reconnectSummary ??
-          `The remote Codex session on ${hostAlias} failed.`,
-      };
-    case "stopped":
-    case "idle":
-      return {
-        kind: "remote",
-        status: "warning",
-        title: "Remote Codex session status",
-        message: reconnectSummary ?? `The remote Codex session on ${hostAlias} is disconnected.`,
-      };
-    case "ready":
-    case "running":
-    case "interrupted":
-      if (!reconnectSummary || session.reconnectState === "fresh-start") {
+      if (!session.lastError) {
         return null;
       }
       return {
         kind: "remote",
-        status: "info",
+        status: "error",
         title: "Remote Codex session status",
-        message: reconnectSummary,
+        message: session.lastError ?? `The remote Codex session on ${hostAlias} failed.`,
       };
+    case "starting":
+    case "stopped":
+    case "idle":
+    case "disconnected":
+      return null;
+    case "ready":
+    case "running":
+    case "interrupted":
+      return null;
   }
 }
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -217,6 +217,40 @@ describe("resolveThreadStatusPill", () => {
       }),
     ).toMatchObject({ label: "Completed", pulse: false });
   });
+
+  it("shows disconnected for stale sessions without higher-priority blockers", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          session: {
+            ...baseThread.session,
+            status: "disconnected",
+            orchestrationStatus: "disconnected",
+          },
+        },
+        hasPendingApprovals: false,
+        hasPendingUserInput: false,
+      }),
+    ).toMatchObject({ label: "Disconnected", pulse: false });
+  });
+
+  it("keeps pending approval above disconnected", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          session: {
+            ...baseThread.session,
+            status: "disconnected",
+            orchestrationStatus: "disconnected",
+          },
+        },
+        hasPendingApprovals: true,
+        hasPendingUserInput: false,
+      }),
+    ).toMatchObject({ label: "Pending Approval", pulse: false });
+  });
 });
 
 describe("resolveThreadRowClassName", () => {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -15,6 +15,7 @@ export interface ThreadStatusPill {
   label:
     | "Working"
     | "Connecting"
+    | "Disconnected"
     | "Completed"
     | "Pending Approval"
     | "Awaiting Input"
@@ -128,6 +129,15 @@ export function resolveThreadStatusPill(input: {
       colorClass: "text-sky-600 dark:text-sky-300/80",
       dotClass: "bg-sky-500 dark:bg-sky-300/80",
       pulse: true,
+    };
+  }
+
+  if (thread.session?.status === "disconnected") {
+    return {
+      label: "Disconnected",
+      colorClass: "text-slate-600 dark:text-slate-300/80",
+      dotClass: "bg-slate-500 dark:bg-slate-300/80",
+      pulse: false,
     };
   }
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -685,7 +685,9 @@ export function inferCheckpointTurnCountByTurnId(
 }
 
 export function derivePhase(session: ThreadSession | null): SessionPhase {
-  if (!session || session.status === "closed") return "disconnected";
+  if (!session || session.status === "closed" || session.status === "disconnected") {
+    return "disconnected";
+  }
   if (session.status === "connecting") return "connecting";
   if (session.status === "running") return "running";
   return "ready";

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -303,6 +303,31 @@ describe("store read model sync", () => {
     });
   });
 
+  it("preserves disconnected orchestration sessions instead of collapsing them to closed", () => {
+    const initialState = makeState(makeThread());
+    const next = syncServerReadModel(
+      initialState,
+      makeReadModel(
+        makeReadModelThread({
+          session: {
+            threadId: ThreadId.makeUnsafe("thread-1"),
+            status: "disconnected",
+            providerName: "codex",
+            runtimeMode: DEFAULT_RUNTIME_MODE,
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: "2026-02-27T00:00:00.000Z",
+          },
+        }),
+      ),
+    );
+
+    expect(next.threads[0]?.session).toMatchObject({
+      status: "disconnected",
+      orchestrationStatus: "disconnected",
+    });
+  });
+
   it("falls back to the codex default for unsupported provider models without an active session", () => {
     const initialState = makeState(makeThread());
     const readModel = makeReadModel(

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -202,12 +202,14 @@ function mapProjectsFromReadModel(
 
 function toLegacySessionStatus(
   status: OrchestrationSessionStatus,
-): "connecting" | "ready" | "running" | "error" | "closed" {
+): "disconnected" | "connecting" | "ready" | "running" | "error" | "closed" {
   switch (status) {
     case "starting":
       return "connecting";
     case "running":
       return "running";
+    case "disconnected":
+      return "disconnected";
     case "error":
       return "error";
     case "ready":

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -314,6 +314,21 @@ it.effect("decodes orchestration session reconnect metadata", () =>
   }),
 );
 
+it.effect("accepts disconnected orchestration sessions", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeOrchestrationSession({
+      threadId: "thread-1",
+      status: "disconnected",
+      providerName: "codex",
+      runtimeMode: "full-access",
+      activeTurnId: null,
+      lastError: null,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    assert.strictEqual(parsed.status, "disconnected");
+  }),
+);
+
 it.effect("defaults proposed plan implementation metadata for historical rows", () =>
   Effect.gen(function* () {
     const parsed = yield* decodeOrchestrationProposedPlan({

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -182,6 +182,7 @@ export const OrchestrationSessionStatus = Schema.Literals([
   "idle",
   "starting",
   "running",
+  "disconnected",
   "ready",
   "interrupted",
   "stopped",
@@ -553,6 +554,17 @@ const ThreadTurnDiffCompleteCommand = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
+const ThreadTurnCompleteCommand = Schema.Struct({
+  type: Schema.Literal("thread.turn.complete"),
+  commandId: CommandId,
+  threadId: ThreadId,
+  turnId: TurnId,
+  state: OrchestrationLatestTurnState,
+  completedAt: IsoDateTime,
+  assistantMessageId: Schema.optional(MessageId),
+  createdAt: IsoDateTime,
+});
+
 const ThreadActivityAppendCommand = Schema.Struct({
   type: Schema.Literal("thread.activity.append"),
   commandId: CommandId,
@@ -575,6 +587,7 @@ const InternalOrchestrationCommand = Schema.Union([
   ThreadMessageAssistantCompleteCommand,
   ThreadProposedPlanUpsertCommand,
   ThreadTurnDiffCompleteCommand,
+  ThreadTurnCompleteCommand,
   ThreadActivityAppendCommand,
   ThreadRevertCompleteCommand,
 ]);
@@ -605,6 +618,7 @@ export const OrchestrationEventType = Schema.Literals([
   "thread.session-stop-requested",
   "thread.session-set",
   "thread.proposed-plan-upserted",
+  "thread.turn-completed",
   "thread.turn-diff-completed",
   "thread.activity-appended",
 ]);
@@ -769,6 +783,14 @@ export const ThreadTurnDiffCompletedPayload = Schema.Struct({
   completedAt: IsoDateTime,
 });
 
+export const ThreadTurnCompletedPayload = Schema.Struct({
+  threadId: ThreadId,
+  turnId: TurnId,
+  state: OrchestrationLatestTurnState,
+  assistantMessageId: Schema.NullOr(MessageId),
+  completedAt: IsoDateTime,
+});
+
 export const ThreadActivityAppendedPayload = Schema.Struct({
   threadId: ThreadId,
   activity: OrchestrationThreadActivity,
@@ -885,6 +907,11 @@ export const OrchestrationEvent = Schema.Union([
     ...EventBaseFields,
     type: Schema.Literal("thread.proposed-plan-upserted"),
     payload: ThreadProposedPlanUpsertedPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
+    type: Schema.Literal("thread.turn-completed"),
+    payload: ThreadTurnCompletedPayload,
   }),
   Schema.Struct({
     ...EventBaseFields,


### PR DESCRIPTION
- mark stale running threads disconnected on startup
- recover, complete, or stop provider sessions as needed
- add thread.turn.complete flow and projection support

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
