### PR TITLE
Handle silent Codex shutdown and recover startup threads

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -393,6 +393,60 @@ describe("startSession", () => {
       manager.stopAll();
     }
   });
+
+  it("supports silent shutdown without emitting session/closed lifecycle events", () => {
+    const manager = new CodexAppServerManager();
+    const emitLifecycleEvent = vi.spyOn(
+      manager as unknown as {
+        emitLifecycleEvent: (...args: unknown[]) => void;
+      },
+      "emitLifecycleEvent",
+    );
+    const updateSession = vi.spyOn(
+      manager as unknown as {
+        updateSession: (...args: unknown[]) => void;
+      },
+      "updateSession",
+    );
+    const sessions = (
+      manager as unknown as {
+        sessions: Map<string, unknown>;
+      }
+    ).sessions;
+
+    sessions.set("thread-1", {
+      session: {
+        provider: "codex",
+        status: "ready",
+        threadId: asThreadId("thread-1"),
+        runtimeMode: "full-access",
+        createdAt: "2026-03-19T00:00:00.000Z",
+        updatedAt: "2026-03-19T00:00:00.000Z",
+      },
+      account: {
+        type: "unknown",
+        planType: null,
+        sparkEnabled: true,
+      },
+      child: {
+        killed: true,
+      },
+      output: {
+        close: vi.fn(),
+      },
+      pending: new Map(),
+      pendingApprovals: new Map(),
+      pendingUserInputs: new Map(),
+      nextRequestId: 1,
+      stopping: false,
+    });
+
+    manager.stopAll({ emitLifecycleEvent: false });
+
+    expect(updateSession).toHaveBeenCalled();
+    expect(emitLifecycleEvent).not.toHaveBeenCalled();
+    expect(sessions.size).toBe(0);
+  });
 });
 
 describe("sendTurn", () => {

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -139,6 +139,10 @@ export interface CodexAppServerStartSessionInput {
   readonly runtimeMode: RuntimeMode;
 }
 
+interface CodexAppServerStopOptions {
+  readonly emitLifecycleEvent?: boolean;
+}
+
 export interface CodexThreadTurnSnapshot {
   id: TurnId;
   items: unknown[];
@@ -1003,7 +1007,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     });
   }
 
-  stopSession(threadId: ThreadId): void {
+  stopSession(threadId: ThreadId, options?: CodexAppServerStopOptions): void {
     const context = this.sessions.get(threadId);
     if (!context) {
       return;
@@ -1029,7 +1033,9 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       status: "closed",
       activeTurnId: undefined,
     });
-    this.emitLifecycleEvent(context, "session/closed", "Session stopped");
+    if (options?.emitLifecycleEvent ?? true) {
+      this.emitLifecycleEvent(context, "session/closed", "Session stopped");
+    }
     this.sessions.delete(threadId);
   }
 
@@ -1043,9 +1049,9 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     return this.sessions.has(threadId);
   }
 
-  stopAll(): void {
+  stopAll(options?: CodexAppServerStopOptions): void {
     for (const threadId of this.sessions.keys()) {
-      this.stopSession(threadId);
+      this.stopSession(threadId, options);
     }
   }
 

--- a/apps/server/src/orchestration/Layers/StartupThreadReconciler.ts
+++ b/apps/server/src/orchestration/Layers/StartupThreadReconciler.ts
@@ -77,6 +77,16 @@ function hasPendingUserInput(thread: OrchestrationThread): boolean {
   return open.size > 0;
 }
 
+function isRecoverableStartupThread(thread: OrchestrationThread): boolean {
+  const status = thread.session?.status;
+  if (status === "running") {
+    return true;
+  }
+  // Older shutdowns could persist resumable sessions as stopped after emitting
+  // session/closed during app teardown. Recover them if the turn never settled.
+  return status === "stopped" && thread.session?.resumeAvailable === true;
+}
+
 function toSessionFromThread(input: {
   readonly thread: OrchestrationThread;
   readonly status: OrchestrationSession["status"];
@@ -264,7 +274,7 @@ const make = Effect.gen(function* () {
     const readModel = yield* orchestrationEngine.getReadModel();
     const candidateIds = readModel.threads
       .filter((thread) => thread.deletedAt === null)
-      .filter((thread) => thread.session?.status === "running")
+      .filter(isRecoverableStartupThread)
       .filter((thread) => thread.latestTurn?.completedAt === null)
       .filter((thread) => !hasPendingApproval(thread))
       .filter((thread) => !hasPendingUserInput(thread))

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1280,7 +1280,7 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
       (manager) =>
         Effect.sync(() => {
           try {
-            manager.stopAll();
+            manager.stopAll({ emitLifecycleEvent: false });
           } catch {
             // Finalizers should never fail and block shutdown.
           }
@@ -1455,7 +1455,7 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
 
     const stopAll: CodexAdapterShape["stopAll"] = () =>
       Effect.sync(() => {
-        manager.stopAll();
+        manager.stopAll({ emitLifecycleEvent: false });
       });
 
     const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();


### PR DESCRIPTION
- suppress session/closed events during adapter teardown
- recover resumable stopped sessions during startup reconciliation
- add coverage for silent stopAll shutdown

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
