### PR TITLE
Feature/composer controls thread

### DIFF
--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -162,11 +162,9 @@ export default function BranchToolbar({
           </Select>
         )}
         {providerThreadId ? (
-          <span className="inline-flex min-w-0 items-center gap-1 text-[11px] text-muted-foreground/60">
-            <span className="shrink-0 uppercase tracking-[0.12em]">Thread ID</span>
-            <code className="max-w-36 truncate rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-foreground/80 sm:max-w-52">
-              {providerThreadId}
-            </code>
+          <span className="inline-flex min-w-0 items-center gap-1 text-sm font-medium text-muted-foreground/70 sm:text-xs">
+            <span className="shrink-0">Thread ID</span>
+            <span>{providerThreadId}</span>
           </span>
         ) : null}
       </div>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -606,10 +606,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const interactionMode = supportedInteractionModes.includes(requestedInteractionMode)
     ? requestedInteractionMode
     : DEFAULT_INTERACTION_MODE;
-  const interactionModeLabel = INTERACTION_MODE_LABEL_BY_OPTION[interactionMode];
-  const InteractionModeIcon = INTERACTION_MODE_ICON_BY_OPTION[interactionMode];
   const nextInteractionMode = getNextInteractionMode(interactionMode, supportedInteractionModes);
-  const nextInteractionModeLabel = INTERACTION_MODE_LABEL_BY_OPTION[nextInteractionMode];
   const baseThreadModel = resolveModelSlugForProvider(
     selectedProvider,
     activeThread?.model ?? activeProject?.model ?? getDefaultModel(selectedProvider),
@@ -3941,14 +3938,26 @@ export default function ChatView({ threadId }: ChatViewProps) {
 
                             <Button
                               variant="ghost"
-                              className="shrink-0 whitespace-nowrap px-2 text-foreground sm:px-3"
+                              className="shrink-0 whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:px-3"
                               size="sm"
                               type="button"
                               onClick={toggleInteractionMode}
-                              title={`Switch to ${nextInteractionModeLabel} mode`}
+                              title={
+                                interactionMode === "plan"
+                                  ? "Plan mode — click to return to normal chat mode"
+                                  : interactionMode === "help"
+                                    ? `Help mode — click to switch to ${INTERACTION_MODE_LABEL_BY_OPTION[nextInteractionMode]} mode`
+                                    : `Default mode — click to enter ${INTERACTION_MODE_LABEL_BY_OPTION[nextInteractionMode]} mode`
+                              }
                             >
-                              <InteractionModeIcon />
-                              <span>{interactionModeLabel}</span>
+                              <INTERACTION_MODE_ICON_BY_OPTION.default />
+                              <span className="sr-only sm:not-sr-only">
+                                {interactionMode === "plan"
+                                  ? "Plan"
+                                  : interactionMode === "help"
+                                    ? "Help"
+                                    : "Chat"}
+                              </span>
                             </Button>
 
                             <Separator


### PR DESCRIPTION
## What Changed

Restyling the input box UI to better align with upstream
<img width="797" height="181" alt="567143997-e0ae04d1-aa28-4229-9da3-650a5b5f63eb" src="https://github.com/user-attachments/assets/811b0c6c-b053-4779-8c85-c8b28d4fc3ba" />


## Why

The new UI has confusing and introduced artifactial drift. This was originally introduced due to some additioanl features like threadID and Kiro supported. 

## Validation

Tested locally 
<img width="802" height="171" alt="Screenshot 2026-03-20 at 7 34 28 PM" src="https://github.com/user-attachments/assets/f4ea051b-13e7-412e-967e-1e21891eb5b1" />

## Maintenance Impact

Reduced as drift from upstream is lower

## UI Changes

Main changes were that the model selection and submission box are back with in the text box and the thread ID is now inline with the workstree selection and the same format

## Checklist
