### PR TITLE
Add structured remote SSH editor targets

### DIFF
--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -131,6 +131,104 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
       assert.equal(result._tag, "Failure");
     }),
   );
+
+  it.effect("maps remote SSH folders for VS Code compatible editors", () =>
+    Effect.gen(function* () {
+      const cursorLaunch = yield* resolveEditorLaunch(
+        {
+          target: {
+            kind: "remote-ssh",
+            hostAlias: "prod",
+            path: "/srv/app",
+            isDirectory: true,
+          },
+          editor: "cursor",
+        },
+        "darwin",
+      );
+      assert.deepEqual(cursorLaunch, {
+        command: "cursor",
+        args: ["--remote", "ssh-remote+prod", "/srv/app/"],
+      });
+
+      const vscodeLaunch = yield* resolveEditorLaunch(
+        {
+          target: {
+            kind: "remote-ssh",
+            hostAlias: "prod",
+            path: "/srv/app",
+            isDirectory: true,
+          },
+          editor: "vscode",
+        },
+        "darwin",
+      );
+      assert.deepEqual(vscodeLaunch, {
+        command: "code",
+        args: ["--remote", "ssh-remote+prod", "/srv/app/"],
+      });
+    }),
+  );
+
+  it.effect("maps remote SSH files for supported editors", () =>
+    Effect.gen(function* () {
+      const cursorLaunch = yield* resolveEditorLaunch(
+        {
+          target: {
+            kind: "remote-ssh",
+            hostAlias: "prod",
+            path: "/srv/app/src/main.ts",
+            isDirectory: false,
+            line: 12,
+            column: 3,
+          },
+          editor: "cursor",
+        },
+        "darwin",
+      );
+      assert.deepEqual(cursorLaunch, {
+        command: "cursor",
+        args: ["--remote", "ssh-remote+prod", "--goto", "/srv/app/src/main.ts:12:3"],
+      });
+
+      const zedLaunch = yield* resolveEditorLaunch(
+        {
+          target: {
+            kind: "remote-ssh",
+            hostAlias: "prod",
+            path: "/srv/app/src/main.ts",
+            isDirectory: false,
+            line: 12,
+            column: 3,
+          },
+          editor: "zed",
+        },
+        "darwin",
+      );
+      assert.deepEqual(zedLaunch, {
+        command: "zed",
+        args: ["ssh://prod/srv/app/src/main.ts:12:3"],
+      });
+    }),
+  );
+
+  it.effect("rejects unsupported editors for remote SSH targets", () =>
+    Effect.gen(function* () {
+      const result = yield* resolveEditorLaunch(
+        {
+          target: {
+            kind: "remote-ssh",
+            hostAlias: "prod",
+            path: "/srv/app",
+            isDirectory: true,
+          },
+          editor: "antigravity",
+        },
+        "darwin",
+      ).pipe(Effect.result);
+      assert.equal(result._tag, "Failure");
+    }),
+  );
 });
 
 it.layer(NodeServices.layer)("launchDetached", (it) => {

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -11,6 +11,7 @@ import { accessSync, constants, statSync } from "node:fs";
 import { extname, join } from "node:path";
 
 import { EDITORS, type EditorId } from "@t3tools/contracts";
+import { supportsRemoteSshEditor } from "@t3tools/shared/editor";
 import { ServiceMap, Schema, Effect, Layer } from "effect";
 
 // ==============================
@@ -22,8 +23,17 @@ export class OpenError extends Schema.TaggedErrorClass<OpenError>()("OpenError",
   cause: Schema.optional(Schema.Defect),
 }) {}
 
+export interface RemoteSshEditorTarget {
+  readonly kind: "remote-ssh";
+  readonly hostAlias: string;
+  readonly path: string;
+  readonly isDirectory: boolean;
+  readonly line?: number;
+  readonly column?: number;
+}
+
 export interface OpenInEditorInput {
-  readonly target: string;
+  readonly target: string | RemoteSshEditorTarget;
   readonly editor: EditorId;
 }
 
@@ -47,6 +57,60 @@ function shouldUseGotoFlag(editorId: EditorId, target: string): boolean {
 
 function isRemoteUriTarget(target: string): boolean {
   return target.startsWith("ssh://");
+}
+
+function isRemoteSshEditorTarget(
+  target: OpenInEditorInput["target"],
+): target is RemoteSshEditorTarget {
+  return typeof target !== "string" && target.kind === "remote-ssh";
+}
+
+function ensureTrailingSlash(pathValue: string): string {
+  return pathValue.endsWith("/") ? pathValue : `${pathValue}/`;
+}
+
+function formatLineAndColumnSuffix(line?: number, column?: number): string {
+  if (typeof line !== "number") {
+    return "";
+  }
+  return `:${line}${typeof column === "number" ? `:${column}` : ""}`;
+}
+
+function formatRemoteSshUri(target: RemoteSshEditorTarget): string {
+  return `ssh://${target.hostAlias}${target.path}${formatLineAndColumnSuffix(target.line, target.column)}`;
+}
+
+function resolveRemoteSshLaunch(
+  target: RemoteSshEditorTarget,
+  editorId: EditorId,
+  command: string,
+): Effect.Effect<EditorLaunch, OpenError> {
+  if (!supportsRemoteSshEditor(editorId)) {
+    return Effect.fail(
+      new OpenError({
+        message: `${EDITORS.find((editor) => editor.id === editorId)?.label ?? editorId} does not support remote SSH editor targets.`,
+      }),
+    );
+  }
+
+  if (editorId === "zed") {
+    return Effect.succeed({
+      command,
+      args: [formatRemoteSshUri(target)],
+    });
+  }
+
+  return Effect.succeed({
+    command,
+    args: target.isDirectory
+      ? ["--remote", `ssh-remote+${target.hostAlias}`, ensureTrailingSlash(target.path)]
+      : [
+          "--remote",
+          `ssh-remote+${target.hostAlias}`,
+          "--goto",
+          `${target.path}${formatLineAndColumnSuffix(target.line, target.column)}`,
+        ],
+  });
 }
 
 function fileManagerCommandForPlatform(platform: NodeJS.Platform): string {
@@ -217,6 +281,9 @@ export const resolveEditorLaunch = Effect.fnUntraced(function* (
   }
 
   if (editorDef.command) {
+    if (isRemoteSshEditorTarget(input.target)) {
+      return yield* resolveRemoteSshLaunch(input.target, editorDef.id, editorDef.command);
+    }
     return shouldUseGotoFlag(editorDef.id, input.target)
       ? { command: editorDef.command, args: ["--goto", input.target] }
       : { command: editorDef.command, args: [input.target] };
@@ -226,7 +293,7 @@ export const resolveEditorLaunch = Effect.fnUntraced(function* (
     return yield* new OpenError({ message: `Unsupported editor: ${input.editor}` });
   }
 
-  if (isRemoteUriTarget(input.target)) {
+  if (typeof input.target !== "string" || isRemoteUriTarget(input.target)) {
     return yield* new OpenError({
       message: "File manager does not support remote SSH editor targets.",
     });

--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -1133,7 +1133,10 @@ describe("WebSocket Server", () => {
     const openService: OpenShape = {
       openBrowser: () => Effect.void,
       openInEditor: (input) => {
-        openCalls.push({ target: input.target, editor: input.editor });
+        openCalls.push({
+          target: typeof input.target === "string" ? input.target : JSON.stringify(input.target),
+          editor: input.editor,
+        });
         return Effect.void;
       },
     };
@@ -1160,7 +1163,10 @@ describe("WebSocket Server", () => {
     const openService: OpenShape = {
       openBrowser: () => Effect.void,
       openInEditor: (input) => {
-        openCalls.push({ target: input.target, editor: input.editor });
+        openCalls.push({
+          target: typeof input.target === "string" ? input.target : JSON.stringify(input.target),
+          editor: input.editor,
+        });
         return Effect.void;
       },
     };
@@ -1227,117 +1233,67 @@ describe("WebSocket Server", () => {
     });
   });
 
-  it("builds ssh editor targets for remote project root and file opens", async () => {
-    const homeDir = makeTempDir("t3code-ssh-home-");
-    fs.mkdirSync(path.join(homeDir, ".ssh"), { recursive: true });
-    fs.writeFileSync(
-      path.join(homeDir, ".ssh", "config"),
-      ["Host prod", "  HostName prod.example.com", "  User alice"].join("\n"),
-      "utf8",
-    );
-    const previousHome = process.env.HOME;
-    process.env.HOME = homeDir;
-
+  it("builds structured ssh editor targets for remote project root and file opens", async () => {
     const openCalls: Array<{ target: string; editor: string }> = [];
     const openService: OpenShape = {
       openBrowser: () => Effect.void,
       openInEditor: (input) => {
-        openCalls.push({ target: input.target, editor: input.editor });
+        openCalls.push({ target: JSON.stringify(input.target), editor: input.editor });
         return Effect.void;
       },
     };
 
-    try {
-      server = await createTestServer({ cwd: "/my/workspace", open: openService });
-      const addr = server.address();
-      const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+    server = await createTestServer({ cwd: "/my/workspace", open: openService });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
 
-      const [ws] = await connectAndAwaitWelcome(port);
-      connections.push(ws);
-      await createProjectAndThread({
-        ws,
-        projectId: "project-remote-open",
-        threadId: "thread-remote-open",
-        workspaceRoot: "/srv/app",
-        remote: { kind: "ssh", hostAlias: "prod" },
-      });
+    const [ws] = await connectAndAwaitWelcome(port);
+    connections.push(ws);
+    await createProjectAndThread({
+      ws,
+      projectId: "project-remote-open",
+      threadId: "thread-remote-open",
+      workspaceRoot: "/srv/app",
+      remote: { kind: "ssh", hostAlias: "prod" },
+    });
 
-      const rootResponse = await sendRequest(ws, WS_METHODS.projectsOpenInEditor, {
-        projectId: "project-remote-open",
+    const rootResponse = await sendRequest(ws, WS_METHODS.projectsOpenInEditor, {
+      projectId: "project-remote-open",
+      editor: "cursor",
+    });
+    expect(rootResponse.error).toBeUndefined();
+
+    const fileResponse = await sendRequest(ws, WS_METHODS.projectsOpenPathInEditor, {
+      projectId: "project-remote-open",
+      threadId: "thread-remote-open",
+      relativePath: "src/main.ts",
+      line: 12,
+      column: 3,
+      editor: "cursor",
+    });
+    expect(fileResponse.error).toBeUndefined();
+    expect(openCalls).toEqual([
+      {
+        target: JSON.stringify({
+          kind: "remote-ssh",
+          hostAlias: "prod",
+          path: "/srv/app",
+          isDirectory: true,
+        }),
         editor: "cursor",
-      });
-      expect(rootResponse.error).toBeUndefined();
-
-      const fileResponse = await sendRequest(ws, WS_METHODS.projectsOpenPathInEditor, {
-        projectId: "project-remote-open",
-        threadId: "thread-remote-open",
-        relativePath: "src/main.ts",
-        line: 12,
-        column: 3,
+      },
+      {
+        target: JSON.stringify({
+          kind: "remote-ssh",
+          hostAlias: "prod",
+          path: "/srv/app/src/main.ts",
+          isDirectory: false,
+          line: 12,
+          column: 3,
+        }),
         editor: "cursor",
-      });
-      expect(fileResponse.error).toBeUndefined();
-      expect(openCalls).toEqual([
-        {
-          target: "ssh://alice@prod.example.com/srv/app",
-          editor: "cursor",
-        },
-        {
-          target: "ssh://alice@prod.example.com/srv/app/src/main.ts",
-          editor: "cursor",
-        },
-      ]);
-    } finally {
-      if (previousHome === undefined) {
-        delete process.env.HOME;
-      } else {
-        process.env.HOME = previousHome;
-      }
-    }
-  });
-
-  it("returns a clear error when remote ssh metadata is incomplete", async () => {
-    const homeDir = makeTempDir("t3code-ssh-home-missing-");
-    fs.mkdirSync(path.join(homeDir, ".ssh"), { recursive: true });
-    fs.writeFileSync(
-      path.join(homeDir, ".ssh", "config"),
-      "Host prod\n  HostName prod.example.com\n",
-      "utf8",
-    );
-    const previousHome = process.env.HOME;
-    process.env.HOME = homeDir;
-
-    try {
-      server = await createTestServer({ cwd: "/my/workspace" });
-      const addr = server.address();
-      const port = typeof addr === "object" && addr !== null ? addr.port : 0;
-
-      const [ws] = await connectAndAwaitWelcome(port);
-      connections.push(ws);
-      await createProjectAndThread({
-        ws,
-        projectId: "project-remote-missing",
-        threadId: "thread-remote-missing",
-        workspaceRoot: "/srv/app",
-        remote: { kind: "ssh", hostAlias: "prod" },
-      });
-
-      const response = await sendRequest(ws, WS_METHODS.projectsOpenPathInEditor, {
-        projectId: "project-remote-missing",
-        threadId: "thread-remote-missing",
-        relativePath: "src/main.ts",
-        editor: "cursor",
-      });
-      expect(response.error).toEqual({
-        message: "SSH host 'prod' is missing a concrete user or hostname.",
-      });
-    } finally {
-      if (previousHome === undefined) {
-        delete process.env.HOME;
-      } else {
-        process.env.HOME = previousHome;
-      }
-    }
+      },
+    ]);
   });
 
   it("reads keybindings from the configured state directory", async () => {

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -786,51 +786,6 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
     };
   });
 
-  const resolveRemoteSshHost = Effect.fnUntraced(function* (hostAlias: string) {
-    const sshHosts = yield* Effect.tryPromise({
-      try: () => listSshHosts(),
-      catch: (cause) =>
-        new RouteRequestError({
-          message: `Failed to resolve SSH host metadata: ${String(cause)}`,
-        }),
-    });
-    const sshHost = sshHosts.find((host) => host.alias === hostAlias);
-    if (!sshHost) {
-      return yield* new RouteRequestError({
-        message: `SSH host '${hostAlias}' was not found in ~/.ssh/config.`,
-      });
-    }
-    const user = sshHost.user;
-    const hostname = sshHost.hostname;
-    if (!user || !hostname) {
-      return yield* new RouteRequestError({
-        message: `SSH host '${hostAlias}' is missing a concrete user or hostname.`,
-      });
-    }
-    return {
-      user,
-      hostname,
-      port: sshHost.port,
-    };
-  });
-
-  const buildRemoteSshEditorTarget = Effect.fnUntraced(function* (input: {
-    readonly hostAlias: string;
-    readonly absolutePath: string;
-  }) {
-    const sshHost = yield* resolveRemoteSshHost(input.hostAlias);
-    const username = sshHost.user;
-    const hostname = sshHost.hostname;
-    const targetUrl = new URL("ssh://placeholder");
-    targetUrl.username = username;
-    targetUrl.hostname = hostname;
-    if (sshHost.port !== null) {
-      targetUrl.port = String(sshHost.port);
-    }
-    targetUrl.pathname = input.absolutePath;
-    return targetUrl.toString();
-  });
-
   const resolveProjectEditorTarget = Effect.fnUntraced(function* (input: {
     readonly projectId: ProjectId;
     readonly threadId?: ThreadId;
@@ -850,10 +805,14 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
         label: "Project path",
         allowWorkspaceRoot: true,
       });
-      return yield* buildRemoteSshEditorTarget({
+      return {
+        kind: "remote-ssh" as const,
         hostAlias: project.remote.hostAlias,
-        absolutePath: resolvedTarget.absolutePath,
-      });
+        path: resolvedTarget.absolutePath,
+        isDirectory: relativePath === ".",
+        ...(typeof input.line === "number" ? { line: input.line } : {}),
+        ...(typeof input.column === "number" ? { column: input.column } : {}),
+      };
     }
 
     const resolvedTarget = yield* resolveWorkspaceRelativePath({

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -4,6 +4,7 @@ import {
   type ResolvedKeybindingsConfig,
   type ThreadId,
 } from "@t3tools/contracts";
+import { filterRemoteSshEditors } from "@t3tools/shared/editor";
 import { memo, useCallback, useEffect, useMemo } from "react";
 import { isOpenFavoriteEditorShortcut, shortcutLabelForCommand } from "../../keybindings";
 import { usePreferredEditor } from "../../editorPreferences";
@@ -14,6 +15,7 @@ import { Menu, MenuItem, MenuPopup, MenuShortcut, MenuTrigger } from "../ui/menu
 import { AntigravityIcon, CursorIcon, Icon, VisualStudioCode, Zed } from "../Icons";
 import { isMacPlatform, isWindowsPlatform } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
+import { toastManager } from "../ui/toast";
 
 const resolveOptions = (
   platform: string,
@@ -51,11 +53,10 @@ const resolveOptions = (
       value: "file-manager",
     },
   ];
-  return baseOptions.filter(
-    (option) =>
-      availableEditors.includes(option.value) &&
-      (!isRemoteProject || option.value !== "file-manager"),
-  );
+  const eligibleEditors = isRemoteProject
+    ? filterRemoteSshEditors(availableEditors)
+    : availableEditors;
+  return baseOptions.filter((option) => eligibleEditors.includes(option.value));
 };
 
 export const OpenInPicker = memo(function OpenInPicker({
@@ -75,12 +76,28 @@ export const OpenInPicker = memo(function OpenInPicker({
   openInProjectRoot: boolean;
   isRemoteProject: boolean;
 }) {
-  const [preferredEditor, setPreferredEditor] = usePreferredEditor(availableEditors);
+  const eligibleEditors = useMemo(
+    () => (isRemoteProject ? filterRemoteSshEditors(availableEditors) : availableEditors),
+    [availableEditors, isRemoteProject],
+  );
+  const [preferredEditor, setPreferredEditor] = usePreferredEditor(eligibleEditors);
   const options = useMemo(
     () => resolveOptions(navigator.platform, availableEditors, isRemoteProject),
     [availableEditors, isRemoteProject],
   );
   const primaryOption = options.find(({ value }) => value === preferredEditor) ?? null;
+
+  const showOpenError = useCallback(
+    (error: unknown) => {
+      toastManager.add({
+        type: "error",
+        title: "Unable to open editor",
+        description: error instanceof Error ? error.message : "An error occurred.",
+        data: { threadId },
+      });
+    },
+    [threadId],
+  );
 
   const openInEditor = useCallback(
     (editorId: EditorId | null) => {
@@ -89,22 +106,32 @@ export const OpenInPicker = memo(function OpenInPicker({
       const editor = editorId ?? preferredEditor;
       if (!editor) return;
       if (openInProjectRoot && projectId) {
-        void api.projects.openInEditor({ projectId, editor });
+        void api.projects.openInEditor({ projectId, editor }).catch(showOpenError);
       } else if (projectId && openInCwd) {
-        void api.projects.openPathInEditor({
-          projectId,
-          ...(threadId ? { threadId } : {}),
-          relativePath: ".",
-          editor,
-        });
+        void api.projects
+          .openPathInEditor({
+            projectId,
+            ...(threadId ? { threadId } : {}),
+            relativePath: ".",
+            editor,
+          })
+          .catch(showOpenError);
       } else if (openInCwd) {
-        void api.shell.openInEditor(openInCwd, editor);
+        void api.shell.openInEditor(openInCwd, editor).catch(showOpenError);
       } else {
         return;
       }
       setPreferredEditor(editor);
     },
-    [openInCwd, openInProjectRoot, preferredEditor, projectId, setPreferredEditor, threadId],
+    [
+      openInCwd,
+      openInProjectRoot,
+      preferredEditor,
+      projectId,
+      setPreferredEditor,
+      showOpenError,
+      threadId,
+    ],
   );
 
   const openFavoriteEditorShortcutLabel = useMemo(
@@ -123,25 +150,37 @@ export const OpenInPicker = memo(function OpenInPicker({
 
       e.preventDefault();
       if (openInProjectRoot && projectId) {
-        void api.projects.openInEditor({ projectId, editor: primaryOption.value });
+        void api.projects
+          .openInEditor({ projectId, editor: primaryOption.value })
+          .catch(showOpenError);
         return;
       }
       if (projectId && openInCwd) {
-        void api.projects.openPathInEditor({
-          projectId,
-          ...(threadId ? { threadId } : {}),
-          relativePath: ".",
-          editor: primaryOption.value,
-        });
+        void api.projects
+          .openPathInEditor({
+            projectId,
+            ...(threadId ? { threadId } : {}),
+            relativePath: ".",
+            editor: primaryOption.value,
+          })
+          .catch(showOpenError);
         return;
       }
       if (openInCwd) {
-        void api.shell.openInEditor(openInCwd, primaryOption.value);
+        void api.shell.openInEditor(openInCwd, primaryOption.value).catch(showOpenError);
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [keybindings, openInCwd, openInProjectRoot, primaryOption, projectId, threadId]);
+  }, [
+    keybindings,
+    openInCwd,
+    openInProjectRoot,
+    primaryOption,
+    projectId,
+    showOpenError,
+    threadId,
+  ]);
 
   const canOpen = primaryOption !== null && ((openInProjectRoot && projectId) || openInCwd);
 
@@ -164,7 +203,13 @@ export const OpenInPicker = memo(function OpenInPicker({
           <ChevronDownIcon aria-hidden="true" className="size-4" />
         </MenuTrigger>
         <MenuPopup align="end">
-          {options.length === 0 && <MenuItem disabled>No installed editors found</MenuItem>}
+          {options.length === 0 && (
+            <MenuItem disabled>
+              {isRemoteProject
+                ? "No compatible remote editors found"
+                : "No installed editors found"}
+            </MenuItem>
+          )}
           {options.map(({ label, Icon, value }) => (
             <MenuItem key={value} onClick={() => openInEditor(value)}>
               <Icon aria-hidden="true" className="text-muted-foreground" />

--- a/apps/web/src/editorPreferences.ts
+++ b/apps/web/src/editorPreferences.ts
@@ -4,6 +4,7 @@ import {
   NativeApi,
   type ProjectOpenPathInEditorInput,
 } from "@t3tools/contracts";
+import { filterRemoteSshEditors } from "@t3tools/shared/editor";
 import { getLocalStorageItem, setLocalStorageItem, useLocalStorage } from "./hooks/useLocalStorage";
 import { useMemo } from "react";
 
@@ -22,8 +23,12 @@ export function usePreferredEditor(availableEditors: ReadonlyArray<EditorId>) {
 
 export function resolveAndPersistPreferredEditor(
   availableEditors: readonly EditorId[],
+  options?: { requireRemoteSsh?: boolean },
 ): EditorId | null {
-  const availableEditorIds = new Set(availableEditors);
+  const eligibleEditors = options?.requireRemoteSsh
+    ? filterRemoteSshEditors(availableEditors)
+    : availableEditors;
+  const availableEditorIds = new Set(eligibleEditors);
   const stored = getLocalStorageItem(LAST_EDITOR_KEY, EditorId);
   if (stored && availableEditorIds.has(stored)) return stored;
   const editor = EDITORS.find((editor) => availableEditorIds.has(editor.id))?.id ?? null;
@@ -33,11 +38,18 @@ export function resolveAndPersistPreferredEditor(
 
 export type PreferredEditorTarget =
   | { kind: "shell"; target: string }
-  | { kind: "project-path"; input: Omit<ProjectOpenPathInEditorInput, "editor"> };
+  | {
+      kind: "project-path";
+      input: Omit<ProjectOpenPathInEditorInput, "editor">;
+      isRemoteProject: boolean;
+    };
 
-async function resolvePreferredEditor(api: NativeApi): Promise<EditorId> {
+async function resolvePreferredEditor(
+  api: NativeApi,
+  options?: { requireRemoteSsh?: boolean },
+): Promise<EditorId> {
   const { availableEditors } = await api.server.getConfig();
-  const editor = resolveAndPersistPreferredEditor(availableEditors);
+  const editor = resolveAndPersistPreferredEditor(availableEditors, options);
   if (!editor) throw new Error("No available editors found.");
   return editor;
 }
@@ -46,7 +58,9 @@ export async function openResolvedEditorTargetInPreferredEditor(
   api: NativeApi,
   target: PreferredEditorTarget,
 ): Promise<EditorId> {
-  const editor = await resolvePreferredEditor(api);
+  const editor = await resolvePreferredEditor(api, {
+    requireRemoteSsh: target.kind === "project-path" && target.isRemoteProject,
+  });
   if (target.kind === "project-path") {
     await api.projects.openPathInEditor({
       ...target.input,

--- a/apps/web/src/projectEditorTargets.test.ts
+++ b/apps/web/src/projectEditorTargets.test.ts
@@ -21,6 +21,7 @@ describe("projectEditorTargets", () => {
       }),
     ).toEqual({
       kind: "project-path",
+      isRemoteProject: false,
       input: {
         projectId,
         threadId,
@@ -66,6 +67,7 @@ describe("projectEditorTargets", () => {
       }),
     ).toEqual({
       kind: "project-path",
+      isRemoteProject: false,
       input: {
         projectId,
         threadId,

--- a/apps/web/src/projectEditorTargets.ts
+++ b/apps/web/src/projectEditorTargets.ts
@@ -15,7 +15,11 @@ export interface ProjectLinkContext {
 }
 
 export type ResolvedEditorTarget =
-  | { kind: "project-path"; input: Omit<ProjectOpenPathInEditorInput, "editor"> }
+  | {
+      kind: "project-path";
+      input: Omit<ProjectOpenPathInEditorInput, "editor">;
+      isRemoteProject: boolean;
+    }
   | { kind: "shell"; target: string };
 
 function isWindowsPathStyle(value: string): boolean {
@@ -141,7 +145,11 @@ function resolveEditorTargetFromResolvedPath(
 
   const projectInput = toProjectPathInput(resolvedTarget, context);
   if (projectInput) {
-    return { kind: "project-path", input: projectInput };
+    return {
+      kind: "project-path",
+      input: projectInput,
+      isRemoteProject: Boolean(context.remote),
+    };
   }
 
   if (context.remote) {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,6 +12,10 @@
       "types": "./src/git.ts",
       "import": "./src/git.ts"
     },
+    "./editor": {
+      "types": "./src/editor.ts",
+      "import": "./src/editor.ts"
+    },
     "./logging": {
       "types": "./src/logging.ts",
       "import": "./src/logging.ts"

--- a/packages/shared/src/editor.ts
+++ b/packages/shared/src/editor.ts
@@ -1,0 +1,13 @@
+import type { EditorId } from "@t3tools/contracts";
+
+const REMOTE_SSH_SUPPORTED_EDITORS = new Set<EditorId>(["cursor", "vscode", "zed"]);
+
+export function supportsRemoteSshEditor(editorId: EditorId): boolean {
+  return REMOTE_SSH_SUPPORTED_EDITORS.has(editorId);
+}
+
+export function filterRemoteSshEditors(
+  editorIds: ReadonlyArray<EditorId>,
+): ReadonlyArray<EditorId> {
+  return editorIds.filter(supportsRemoteSshEditor);
+}


### PR DESCRIPTION
- Preserve remote project metadata from server to UI
- Support remote SSH opens in compatible editors
- Filter unsupported editors and surface open errors

## What Changed

## Why


## Validation


## Maintenance Impact


## UI Changes

## Checklist
