### PR TITLE
Unify local and SSH provider overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,55 +28,6 @@ The implementation in this fork currently targets Codex-first remote workflows:
 
 This is still early-stage software. Expect rough edges and incomplete provider coverage.
 
-## Provider Implementation Comparison
-
-T3 Code uses a shared provider abstraction, but each provider runtime is implemented differently underneath it.
-
-### Shared Architecture
-
-All three providers plug into the same server-side provider stack:
-
-- provider adapter contract in `apps/server/src/provider/Services/ProviderAdapter.ts`
-- cross-provider routing and recovery in `apps/server/src/provider/Layers/ProviderService.ts`
-- persisted thread-to-provider bindings in `apps/server/src/provider/Layers/ProviderSessionDirectory.ts`
-- shared orchestration integration in `apps/server/src/orchestration/Layers/ProviderCommandReactor.ts`
-- shared runtime event ingestion in `apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts`
-
-That means the providers are not completely separate. Their runtime/protocol layers are provider-specific, but orchestration, persistence, settings, and UI model-selection flows are shared.
-
-### Matrix
-
-| Provider    | Control structure                                                                                       | Session / resume                                                                                          | Approvals | Structured user input | Rollback / checkpoint revert                                          | Remote support                                                        | Complexity | Main strengths                                                                                | Main weaknesses                                                                                   |
-| ----------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | --------- | --------------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------- | ---------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| Codex       | `codex app-server` over JSON-RPC on stdio, wrapped by `codexAppServerManager.ts` plus `CodexAdapter.ts` | Strongest native thread model. Uses `thread/start`, `thread/resume`, and persists `resumeCursor.threadId` | Yes       | Yes                   | Yes, via `thread/rollback`                                            | Yes, including SSH plus host-scoped binary and `CODEX_HOME` overrides | Highest    | Richest protocol, best feature coverage, strongest recovery model                             | Most protocol glue, version/env handling, resume fallback cases, and child-conversation filtering |
-| Claude Code | Direct `@anthropic-ai/claude-agent-sdk` query session inside `ClaudeAdapter.ts`                         | Good, but adapter-managed rather than external thread RPC. Uses SDK resume/session ids in `resumeCursor`  | Yes       | Yes                   | Yes, by trimming local adapter turn history and updating resume state | No dedicated remote transport layer in this repo                      | Medium     | Cleanest implementation, fewer moving parts, direct in-session model and permission switching | Recovery behavior depends more on adapter-owned state and SDK semantics                           |
-| Kiro        | ACP over JSON-RPC on stdio, wrapped by `kiroAcpManager.ts` plus `KiroAdapter.ts`                        | Weaker than Codex. Uses `session/new` and `session/load` with `resumeCursor.sessionId`                    | Yes       | No                    | No. Checkpoint revert is explicitly unsupported for Kiro threads      | Yes, via provider options passed into the ACP manager                 | Lowest     | Smallest implementation, simplest ACP mapping, clean mode switching                           | Least feature-complete, weaker recovery, no structured user input, no rollback                    |
-
-### Provider-Specific Files
-
-- Codex: `apps/server/src/codexAppServerManager.ts`, `apps/server/src/provider/Layers/CodexAdapter.ts`, `apps/server/src/provider/codexCliVersion.ts`
-- Claude Code: `apps/server/src/provider/Layers/ClaudeAdapter.ts`
-- Kiro: `apps/server/src/kiroAcpManager.ts`, `apps/server/src/provider/Layers/KiroAdapter.ts`
-
-### Shared Files Touched By All Providers
-
-- Contracts: `packages/contracts/src/provider.ts`, `packages/contracts/src/providerRuntime.ts`, `packages/contracts/src/orchestration.ts`, `packages/contracts/src/model.ts`
-- Server orchestration: `apps/server/src/provider/Layers/ProviderService.ts`, `apps/server/src/provider/Layers/ProviderSessionDirectory.ts`, `apps/server/src/provider/Layers/ProviderAdapterRegistry.ts`
-- Orchestration runtime flow: `apps/server/src/orchestration/Layers/ProviderCommandReactor.ts`, `apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts`, `apps/server/src/orchestration/Layers/StartupThreadReconciler.ts`, `apps/server/src/orchestration/Layers/CheckpointReactor.ts`
-- Web settings and provider selection: `apps/web/src/appSettings.ts`, `apps/web/src/routes/_chat.settings.tsx`, `apps/web/src/components/chat/composerProviderRegistry.tsx`
-
-### Kiro Alignment Summary
-
-Kiro aligns with the same adapter-based architecture as Codex and Claude Code. It satisfies the same high-level provider contract and participates in the same orchestration and persistence layers.
-
-Its gap is capability, not architecture. Compared with Codex and Claude Code, Kiro is currently weaker in three important ways:
-
-- no structured user-input response support
-- no conversation rollback support
-- weaker recovery semantics, with more fallback-to-fresh-session behavior when persisted resume state is unavailable
-
-The upside is that Kiro is also the simplest provider implementation in the repo. Its ACP integration is smaller, easier to reason about, and cleaner than the Codex app-server integration.
-
 ## Getting Started
 
 > [!WARNING]

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -189,6 +189,7 @@ describe("getProviderStartOptions", () => {
     expect(
       getProviderStartOptions({
         claudeBinaryPath: "/usr/local/bin/claude",
+        claudeRemoteOverrides: {},
         codexBinaryPath: "",
         codexHomePath: "/Users/you/.codex",
         codexRemoteOverrides: {},
@@ -210,6 +211,11 @@ describe("getProviderStartOptions", () => {
       getProviderStartOptions(
         {
           claudeBinaryPath: "/usr/local/bin/claude",
+          claudeRemoteOverrides: {
+            "prod-box": {
+              binaryPath: "/opt/claude/bin/claude",
+            },
+          },
           codexBinaryPath: "/usr/local/bin/codex",
           codexHomePath: "/Users/you/.codex",
           codexRemoteOverrides: {
@@ -229,7 +235,7 @@ describe("getProviderStartOptions", () => {
       ),
     ).toEqual({
       claudeAgent: {
-        binaryPath: "/usr/local/bin/claude",
+        binaryPath: "/opt/claude/bin/claude",
       },
       codex: {
         binaryPath: "/opt/codex/bin/codex",
@@ -245,6 +251,7 @@ describe("getProviderStartOptions", () => {
     expect(
       getProviderStartOptions({
         claudeBinaryPath: "",
+        claudeRemoteOverrides: {},
         codexBinaryPath: "",
         codexHomePath: "",
         codexRemoteOverrides: {},
@@ -367,6 +374,7 @@ describe("AppSettingsSchema", () => {
       ),
     ).toMatchObject({
       claudeBinaryPath: "",
+      claudeRemoteOverrides: {},
       codexBinaryPath: "/usr/local/bin/codex",
       codexHomePath: "",
       defaultThreadEnvMode: "local",

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -71,8 +71,18 @@ const KiroHostOverrideSchema = Schema.Struct({
 export type KiroHostOverride = typeof KiroHostOverrideSchema.Type;
 const DEFAULT_KIRO_HOST_OVERRIDE = KiroHostOverrideSchema.makeUnsafe({});
 
+const ClaudeHostOverrideSchema = Schema.Struct({
+  binaryPath: SettingsPathSchema,
+});
+export type ClaudeHostOverride = typeof ClaudeHostOverrideSchema.Type;
+const DEFAULT_CLAUDE_HOST_OVERRIDE = ClaudeHostOverrideSchema.makeUnsafe({});
+
 export const AppSettingsSchema = Schema.Struct({
   claudeBinaryPath: SettingsPathSchema,
+  claudeRemoteOverrides: Schema.Record(Schema.String, ClaudeHostOverrideSchema).pipe(
+    Schema.withConstructorDefault(() => Option.some({})),
+    Schema.withDecodingDefault(() => ({})),
+  ),
   codexBinaryPath: SettingsPathSchema,
   codexHomePath: SettingsPathSchema,
   codexRemoteOverrides: Schema.Record(Schema.String, CodexHostOverrideSchema).pipe(
@@ -206,6 +216,52 @@ export function buildCodexHostOverridePatch(
   return { codexRemoteOverrides };
 }
 
+export function getClaudeHostOverride(
+  settings: Pick<AppSettings, "claudeBinaryPath" | "claudeRemoteOverrides">,
+  hostAlias?: string | null,
+): ClaudeHostOverride {
+  if (!hostAlias) {
+    return {
+      binaryPath: settings.claudeBinaryPath,
+    };
+  }
+
+  const override = settings.claudeRemoteOverrides[hostAlias];
+  if (!override) {
+    return { ...DEFAULT_CLAUDE_HOST_OVERRIDE };
+  }
+
+  return {
+    binaryPath: override.binaryPath,
+  };
+}
+
+export function buildClaudeHostOverridePatch(
+  settings: Pick<AppSettings, "claudeBinaryPath" | "claudeRemoteOverrides">,
+  patch: Partial<ClaudeHostOverride>,
+  hostAlias?: string | null,
+): Partial<AppSettings> {
+  const nextOverride = {
+    ...getClaudeHostOverride(settings, hostAlias),
+    ...patch,
+  };
+
+  if (!hostAlias) {
+    return {
+      claudeBinaryPath: nextOverride.binaryPath,
+    };
+  }
+
+  const claudeRemoteOverrides = { ...settings.claudeRemoteOverrides };
+  if (!nextOverride.binaryPath) {
+    delete claudeRemoteOverrides[hostAlias];
+  } else {
+    claudeRemoteOverrides[hostAlias] = nextOverride;
+  }
+
+  return { claudeRemoteOverrides };
+}
+
 export function getKiroHostOverride(
   settings: Pick<AppSettings, "kiroBinaryPath" | "kiroRemoteOverrides">,
   hostAlias?: string | null,
@@ -278,6 +334,7 @@ export function getProviderStartOptions(
   settings: Pick<
     AppSettings,
     | "claudeBinaryPath"
+    | "claudeRemoteOverrides"
     | "codexBinaryPath"
     | "codexHomePath"
     | "codexRemoteOverrides"
@@ -286,14 +343,15 @@ export function getProviderStartOptions(
   >,
   hostAlias?: string | null,
 ): ProviderStartOptions | undefined {
+  const claude = getClaudeHostOverride(settings, hostAlias);
   const codex = getCodexHostOverride(settings, hostAlias);
   const kiro = getKiroHostOverride(settings, hostAlias);
 
   const providerOptions: ProviderStartOptions = {
-    ...(settings.claudeBinaryPath
+    ...(claude.binaryPath
       ? {
           claudeAgent: {
-            binaryPath: settings.claudeBinaryPath,
+            binaryPath: claude.binaryPath,
           },
         }
       : {}),

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -285,6 +285,7 @@ function buildFixture(snapshot: OrchestrationReadModel): TestFixture {
 function buildAppSettings(overrides: Partial<AppSettings> = {}): AppSettings {
   return {
     claudeBinaryPath: "",
+    claudeRemoteOverrides: {},
     codexBinaryPath: "",
     codexHomePath: "",
     codexRemoteOverrides: {},

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -5,15 +5,16 @@ import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react
 import { type DesktopAppCloseBehavior, type ProviderKind } from "@t3tools/contracts";
 import { getModelOptions, normalizeModelSlug } from "@t3tools/shared/model";
 import {
+  buildClaudeHostOverridePatch,
   GIT_DEFAULT_ACTION_OPTIONS,
   THREAD_ID_DISPLAY_MODE_OPTIONS,
   type GitDefaultAction,
   type ThreadIdDisplayMode,
+  getClaudeHostOverride,
   buildCodexHostOverridePatch,
   buildKiroHostOverridePatch,
   getCodexHostOverride,
   getKiroHostOverride,
-  getProviderStartOptions,
   useAppSettings,
 } from "../appSettings";
 import {
@@ -114,7 +115,10 @@ type InstallProviderSettings = {
   binaryPathKey: InstallBinarySettingsKey;
   binaryPlaceholder: string;
   binaryDescription: ReactNode;
+  binaryLabel?: string;
   homePathKey?: "codexHomePath";
+  localDescription?: string;
+  remoteDescription?: string;
   homePlaceholder?: string;
   homeDescription?: ReactNode;
 };
@@ -124,12 +128,15 @@ const INSTALL_PROVIDER_SETTINGS: readonly InstallProviderSettings[] = [
     provider: "codex",
     title: "Codex",
     binaryPathKey: "codexBinaryPath",
+    binaryLabel: "Codex binary path",
     binaryPlaceholder: "Codex binary path",
     binaryDescription: (
       <>
         Leave blank to use <code>codex</code> from your PATH.
       </>
     ),
+    localDescription: "Override the CLI used for new local sessions.",
+    remoteDescription: "Override the Codex binary and CODEX_HOME for a specific SSH host.",
     homePathKey: "codexHomePath",
     homePlaceholder: "CODEX_HOME",
     homeDescription: "Optional custom Codex home and config directory.",
@@ -138,23 +145,29 @@ const INSTALL_PROVIDER_SETTINGS: readonly InstallProviderSettings[] = [
     provider: "claudeAgent",
     title: "Claude",
     binaryPathKey: "claudeBinaryPath",
+    binaryLabel: "Claude binary path",
     binaryPlaceholder: "Claude binary path",
     binaryDescription: (
       <>
         Leave blank to use <code>claude</code> from your PATH.
       </>
     ),
+    localDescription: "Override the CLI used for new local sessions.",
+    remoteDescription: "Override the Claude binary for a specific SSH host.",
   },
   {
     provider: "kiro",
     title: "Kiro CLI",
     binaryPathKey: "kiroBinaryPath",
+    binaryLabel: "Kiro binary path",
     binaryPlaceholder: "Kiro binary path",
     binaryDescription: (
       <>
         Leave blank to use <code>kiro-cli</code> from your PATH.
       </>
     ),
+    localDescription: "Override the CLI used for new local sessions.",
+    remoteDescription: "Override the Kiro CLI binary for a specific SSH host.",
   },
 ];
 
@@ -249,6 +262,8 @@ function arraysEqual(left: readonly string[], right: readonly string[]) {
   return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
+type OverrideMode = "local" | "ssh";
+
 function SettingsRouteView() {
   const { theme, setTheme } = useTheme();
   const { settings, defaults, updateSettings, resetSettings } = useAppSettings();
@@ -257,10 +272,35 @@ function SettingsRouteView() {
   const [isOpeningKeybindings, setIsOpeningKeybindings] = useState(false);
   const [openKeybindingsError, setOpenKeybindingsError] = useState<string | null>(null);
   const [openInstallProviders, setOpenInstallProviders] = useState<Record<ProviderKind, boolean>>({
-    codex: Boolean(settings.codexBinaryPath || settings.codexHomePath),
-    claudeAgent: Boolean(settings.claudeBinaryPath),
-    kiro: Boolean(settings.kiroBinaryPath),
+    claudeAgent: Boolean(
+      settings.claudeBinaryPath || Object.keys(settings.claudeRemoteOverrides).length > 0,
+    ),
+    codex: Boolean(
+      settings.codexBinaryPath ||
+      settings.codexHomePath ||
+      Object.keys(settings.codexRemoteOverrides).length > 0,
+    ),
+    kiro: Boolean(settings.kiroBinaryPath || Object.keys(settings.kiroRemoteOverrides).length > 0),
   });
+  const [providerOverrideMode, setProviderOverrideMode] = useState<
+    Record<ProviderKind, OverrideMode>
+  >({
+    codex:
+      Object.keys(settings.codexRemoteOverrides).length > 0 &&
+      !settings.codexBinaryPath &&
+      !settings.codexHomePath
+        ? "ssh"
+        : "local",
+    claudeAgent:
+      Object.keys(settings.claudeRemoteOverrides).length > 0 && !settings.claudeBinaryPath
+        ? "ssh"
+        : "local",
+    kiro:
+      Object.keys(settings.kiroRemoteOverrides).length > 0 && !settings.kiroBinaryPath
+        ? "ssh"
+        : "local",
+  });
+  const [selectedClaudeRemoteHost, setSelectedClaudeRemoteHost] = useState<string | null>(null);
   const [selectedCodexRemoteHost, setSelectedCodexRemoteHost] = useState<string | null>(null);
   const [selectedKiroRemoteHost, setSelectedKiroRemoteHost] = useState<string | null>(null);
   const [selectedCustomModelProvider, setSelectedCustomModelProvider] =
@@ -289,20 +329,20 @@ function SettingsRouteView() {
     [projects],
   );
 
-  const codexRemoteHosts = useMemo(
-    () =>
-      Array.from(
-        new Set([...sshProjectHostAliases, ...Object.keys(settings.codexRemoteOverrides)]),
-      ).toSorted((left, right) => left.localeCompare(right)),
-    [settings.codexRemoteOverrides, sshProjectHostAliases],
-  );
-  const kiroRemoteHosts = useMemo(
-    () =>
-      Array.from(
-        new Set([...sshProjectHostAliases, ...Object.keys(settings.kiroRemoteOverrides)]),
-      ).toSorted((left, right) => left.localeCompare(right)),
-    [settings.kiroRemoteOverrides, sshProjectHostAliases],
-  );
+  const claudeRemoteHosts = sshProjectHostAliases;
+  const codexRemoteHosts = sshProjectHostAliases;
+  const kiroRemoteHosts = sshProjectHostAliases;
+
+  useEffect(() => {
+    if (claudeRemoteHosts.length === 0) {
+      setSelectedClaudeRemoteHost(null);
+      return;
+    }
+
+    if (!selectedClaudeRemoteHost || !claudeRemoteHosts.includes(selectedClaudeRemoteHost)) {
+      setSelectedClaudeRemoteHost(claudeRemoteHosts[0] ?? null);
+    }
+  }, [claudeRemoteHosts, selectedClaudeRemoteHost]);
 
   useEffect(() => {
     if (codexRemoteHosts.length === 0) {
@@ -326,6 +366,9 @@ function SettingsRouteView() {
     }
   }, [kiroRemoteHosts, selectedKiroRemoteHost]);
 
+  const selectedClaudeRemoteOverride = selectedClaudeRemoteHost
+    ? getClaudeHostOverride(settings, selectedClaudeRemoteHost)
+    : null;
   const selectedCodexRemoteOverride = selectedCodexRemoteHost
     ? getCodexHostOverride(settings, selectedCodexRemoteHost)
     : null;
@@ -384,12 +427,20 @@ function SettingsRouteView() {
     settings.codexHomePath !== defaults.codexHomePath ||
     settings.kiroBinaryPath !== defaults.kiroBinaryPath;
 
+  const hasClaudeRemoteOverrides = Object.keys(settings.claudeRemoteOverrides).length > 0;
   const hasCodexRemoteOverrides = Object.keys(settings.codexRemoteOverrides).length > 0;
   const hasKiroRemoteOverrides = Object.keys(settings.kiroRemoteOverrides).length > 0;
+  const hasSelectedClaudeRemoteOverride = Boolean(selectedClaudeRemoteOverride?.binaryPath);
   const hasSelectedCodexRemoteOverride = Boolean(
     selectedCodexRemoteOverride?.binaryPath || selectedCodexRemoteOverride?.homePath,
   );
   const hasSelectedKiroRemoteOverride = Boolean(selectedKiroRemoteOverride?.binaryPath);
+
+  const hasCodexLocalOverride =
+    settings.codexBinaryPath !== defaults.codexBinaryPath ||
+    settings.codexHomePath !== defaults.codexHomePath;
+  const hasClaudeLocalOverride = settings.claudeBinaryPath !== defaults.claudeBinaryPath;
+  const hasKiroLocalOverride = settings.kiroBinaryPath !== defaults.kiroBinaryPath;
 
   const changedSettingLabels = [
     ...(theme !== "system" ? ["Theme"] : []),
@@ -410,6 +461,7 @@ function SettingsRouteView() {
     ...(hasGitOverrides ? ["Git settings"] : []),
     ...(hasCustomModelOverrides ? ["Custom models"] : []),
     ...(isInstallSettingsDirty ? ["Provider installs"] : []),
+    ...(hasClaudeRemoteOverrides ? ["Claude SSH overrides"] : []),
     ...(hasCodexRemoteOverrides ? ["Codex SSH overrides"] : []),
     ...(hasKiroRemoteOverrides ? ["Kiro SSH overrides"] : []),
   ];
@@ -1182,22 +1234,33 @@ function SettingsRouteView() {
             <SettingsSection title="Advanced">
               <SettingsRow
                 title="Provider installs"
-                description="Override the CLI used for new local sessions. SSH-specific overrides are configured below."
+                description="Override local installs and SSH host-specific binaries for each provider."
                 resetAction={
-                  isInstallSettingsDirty ? (
+                  isInstallSettingsDirty ||
+                  hasClaudeRemoteOverrides ||
+                  hasCodexRemoteOverrides ||
+                  hasKiroRemoteOverrides ? (
                     <SettingResetButton
                       label="provider installs"
                       onClick={() => {
                         updateSettings({
                           claudeBinaryPath: defaults.claudeBinaryPath,
+                          claudeRemoteOverrides: defaults.claudeRemoteOverrides,
                           codexBinaryPath: defaults.codexBinaryPath,
                           codexHomePath: defaults.codexHomePath,
+                          codexRemoteOverrides: defaults.codexRemoteOverrides,
                           kiroBinaryPath: defaults.kiroBinaryPath,
+                          kiroRemoteOverrides: defaults.kiroRemoteOverrides,
                         });
                         setOpenInstallProviders({
                           codex: false,
                           claudeAgent: false,
                           kiro: false,
+                        });
+                        setProviderOverrideMode({
+                          codex: "local",
+                          claudeAgent: "local",
+                          kiro: "local",
                         });
                       }}
                     />
@@ -1208,19 +1271,129 @@ function SettingsRouteView() {
                   <div className="space-y-2">
                     {INSTALL_PROVIDER_SETTINGS.map((providerSettings) => {
                       const isOpen = openInstallProviders[providerSettings.provider];
-                      const isDirty =
+                      const selectedMode = providerOverrideMode[providerSettings.provider];
+                      const supportsRemote =
+                        providerSettings.provider === "claudeAgent" ||
+                        providerSettings.provider === "codex" ||
+                        providerSettings.provider === "kiro";
+                      const remoteHosts =
+                        providerSettings.provider === "claudeAgent"
+                          ? claudeRemoteHosts
+                          : providerSettings.provider === "codex"
+                            ? codexRemoteHosts
+                            : providerSettings.provider === "kiro"
+                              ? kiroRemoteHosts
+                              : [];
+                      const selectedRemoteHost =
+                        providerSettings.provider === "claudeAgent"
+                          ? selectedClaudeRemoteHost
+                          : providerSettings.provider === "codex"
+                            ? selectedCodexRemoteHost
+                            : providerSettings.provider === "kiro"
+                              ? selectedKiroRemoteHost
+                              : null;
+                      const selectedRemoteOverride =
+                        providerSettings.provider === "claudeAgent"
+                          ? selectedClaudeRemoteOverride
+                          : providerSettings.provider === "codex"
+                            ? selectedCodexRemoteOverride
+                            : providerSettings.provider === "kiro"
+                              ? selectedKiroRemoteOverride
+                              : null;
+                      const canSelectRemote = supportsRemote && remoteHosts.length > 0;
+                      const effectiveSelectedMode =
+                        selectedMode === "ssh" && canSelectRemote ? "ssh" : "local";
+                      const isLocalDirty =
                         providerSettings.provider === "codex"
-                          ? settings.codexBinaryPath !== defaults.codexBinaryPath ||
-                            settings.codexHomePath !== defaults.codexHomePath
+                          ? hasCodexLocalOverride
                           : providerSettings.provider === "claudeAgent"
-                            ? settings.claudeBinaryPath !== defaults.claudeBinaryPath
-                            : settings.kiroBinaryPath !== defaults.kiroBinaryPath;
+                            ? hasClaudeLocalOverride
+                            : hasKiroLocalOverride;
+                      const isRemoteDirty =
+                        providerSettings.provider === "claudeAgent"
+                          ? hasClaudeRemoteOverrides
+                          : providerSettings.provider === "codex"
+                            ? hasCodexRemoteOverrides
+                            : providerSettings.provider === "kiro"
+                              ? hasKiroRemoteOverrides
+                              : false;
+                      const isSelectedRemoteDirty =
+                        providerSettings.provider === "claudeAgent"
+                          ? hasSelectedClaudeRemoteOverride
+                          : providerSettings.provider === "codex"
+                            ? hasSelectedCodexRemoteOverride
+                            : providerSettings.provider === "kiro"
+                              ? hasSelectedKiroRemoteOverride
+                              : false;
+                      const isDirty = isLocalDirty || isRemoteDirty;
                       const binaryPathValue =
                         providerSettings.binaryPathKey === "claudeBinaryPath"
                           ? settings.claudeBinaryPath
                           : providerSettings.binaryPathKey === "kiroBinaryPath"
                             ? settings.kiroBinaryPath
                             : settings.codexBinaryPath;
+                      const resetAction =
+                        effectiveSelectedMode === "local" ? (
+                          isLocalDirty ? (
+                            <SettingResetButton
+                              label={`${providerSettings.title.toLowerCase()} local override`}
+                              onClick={() => {
+                                if (providerSettings.provider === "codex") {
+                                  updateSettings({
+                                    codexBinaryPath: defaults.codexBinaryPath,
+                                    codexHomePath: defaults.codexHomePath,
+                                  });
+                                  return;
+                                }
+                                if (providerSettings.provider === "claudeAgent") {
+                                  updateSettings({
+                                    claudeBinaryPath: defaults.claudeBinaryPath,
+                                  });
+                                  return;
+                                }
+                                updateSettings({
+                                  kiroBinaryPath: defaults.kiroBinaryPath,
+                                });
+                              }}
+                            />
+                          ) : null
+                        ) : supportsRemote && selectedRemoteHost && isSelectedRemoteDirty ? (
+                          <SettingResetButton
+                            label={`${providerSettings.title.toLowerCase()} ssh override`}
+                            onClick={() => {
+                              if (providerSettings.provider === "claudeAgent") {
+                                updateSettings(
+                                  buildClaudeHostOverridePatch(
+                                    settings,
+                                    { binaryPath: "" },
+                                    selectedRemoteHost,
+                                  ),
+                                );
+                                return;
+                              }
+                              if (providerSettings.provider === "codex") {
+                                updateSettings(
+                                  buildCodexHostOverridePatch(
+                                    settings,
+                                    {
+                                      binaryPath: "",
+                                      homePath: "",
+                                    },
+                                    selectedRemoteHost,
+                                  ),
+                                );
+                                return;
+                              }
+                              updateSettings(
+                                buildKiroHostOverridePatch(
+                                  settings,
+                                  { binaryPath: "" },
+                                  selectedRemoteHost,
+                                ),
+                              );
+                            }}
+                          />
+                        ) : null;
 
                       return (
                         <Collapsible
@@ -1261,61 +1434,258 @@ function SettingsRouteView() {
                             <CollapsibleContent>
                               <div className="border-t border-border/70 px-4 py-4">
                                 <div className="space-y-3">
-                                  <label
-                                    htmlFor={`provider-install-${providerSettings.binaryPathKey}`}
-                                    className="block"
-                                  >
-                                    <span className="block text-xs font-medium text-foreground">
-                                      {providerSettings.title} binary path
+                                  <div className="flex items-start justify-between gap-3">
+                                    <p className="min-w-0 flex-1 text-xs text-muted-foreground">
+                                      {(effectiveSelectedMode === "ssh"
+                                        ? providerSettings.remoteDescription
+                                        : providerSettings.localDescription) ??
+                                        "Override the provider binary path."}
+                                    </p>
+                                    <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center">
+                                      {resetAction}
                                     </span>
-                                    <Input
-                                      id={`provider-install-${providerSettings.binaryPathKey}`}
-                                      className="mt-1"
-                                      value={binaryPathValue}
-                                      onChange={(event) =>
-                                        updateSettings(
-                                          providerSettings.binaryPathKey === "claudeBinaryPath"
-                                            ? { claudeBinaryPath: event.target.value }
-                                            : providerSettings.binaryPathKey === "kiroBinaryPath"
-                                              ? { kiroBinaryPath: event.target.value }
-                                              : { codexBinaryPath: event.target.value },
-                                        )
-                                      }
-                                      placeholder={providerSettings.binaryPlaceholder}
-                                      spellCheck={false}
-                                    />
-                                    <span className="mt-1 block text-xs text-muted-foreground">
-                                      {providerSettings.binaryDescription}
-                                    </span>
-                                  </label>
+                                  </div>
 
-                                  {providerSettings.homePathKey ? (
+                                  {supportsRemote ? (
                                     <label
-                                      htmlFor={`provider-install-${providerSettings.homePathKey}`}
+                                      htmlFor={`provider-install-mode-${providerSettings.provider}`}
                                       className="block"
                                     >
                                       <span className="block text-xs font-medium text-foreground">
-                                        CODEX_HOME path
+                                        Override target
                                       </span>
-                                      <Input
-                                        id={`provider-install-${providerSettings.homePathKey}`}
-                                        className="mt-1"
-                                        value={settings.codexHomePath}
-                                        onChange={(event) =>
-                                          updateSettings({
-                                            codexHomePath: event.target.value,
-                                          })
-                                        }
-                                        placeholder={providerSettings.homePlaceholder}
-                                        spellCheck={false}
-                                      />
-                                      {providerSettings.homeDescription ? (
-                                        <span className="mt-1 block text-xs text-muted-foreground">
-                                          {providerSettings.homeDescription}
-                                        </span>
-                                      ) : null}
+                                      <Select
+                                        value={effectiveSelectedMode}
+                                        onValueChange={(value) => {
+                                          if (value !== "local" && value !== "ssh") return;
+                                          if (value === "ssh" && !canSelectRemote) return;
+                                          setProviderOverrideMode((existing) => ({
+                                            ...existing,
+                                            [providerSettings.provider]: value,
+                                          }));
+                                        }}
+                                      >
+                                        <SelectTrigger
+                                          id={`provider-install-mode-${providerSettings.provider}`}
+                                          className="mt-1 w-full"
+                                          disabled={!canSelectRemote}
+                                          aria-label={`${providerSettings.title} override target`}
+                                        >
+                                          <SelectValue>
+                                            {effectiveSelectedMode === "ssh" ? "SSH host" : "Local"}
+                                          </SelectValue>
+                                        </SelectTrigger>
+                                        <SelectPopup align="start" alignItemWithTrigger={false}>
+                                          <SelectItem hideIndicator value="local">
+                                            Local
+                                          </SelectItem>
+                                          {canSelectRemote ? (
+                                            <SelectItem hideIndicator value="ssh">
+                                              SSH host
+                                            </SelectItem>
+                                          ) : null}
+                                        </SelectPopup>
+                                      </Select>
                                     </label>
                                   ) : null}
+
+                                  {effectiveSelectedMode === "ssh" && supportsRemote ? (
+                                    remoteHosts.length > 0 ? (
+                                      <>
+                                        <label
+                                          htmlFor={`provider-install-ssh-host-${providerSettings.provider}`}
+                                          className="block"
+                                        >
+                                          <span className="block text-xs font-medium text-foreground">
+                                            SSH host
+                                          </span>
+                                          <Select
+                                            value={selectedRemoteHost ?? ""}
+                                            onValueChange={(value) => {
+                                              if (typeof value !== "string") return;
+                                              if (!remoteHosts.includes(value)) return;
+                                              if (providerSettings.provider === "claudeAgent") {
+                                                setSelectedClaudeRemoteHost(value);
+                                                return;
+                                              }
+                                              if (providerSettings.provider === "codex") {
+                                                setSelectedCodexRemoteHost(value);
+                                                return;
+                                              }
+                                              setSelectedKiroRemoteHost(value);
+                                            }}
+                                          >
+                                            <SelectTrigger
+                                              id={`provider-install-ssh-host-${providerSettings.provider}`}
+                                              className="mt-1 w-full"
+                                              aria-label={`${providerSettings.title} SSH override host`}
+                                            >
+                                              <SelectValue>
+                                                {selectedRemoteHost ?? "Select host"}
+                                              </SelectValue>
+                                            </SelectTrigger>
+                                            <SelectPopup align="start" alignItemWithTrigger={false}>
+                                              {remoteHosts.map((hostAlias) => (
+                                                <SelectItem
+                                                  hideIndicator
+                                                  key={hostAlias}
+                                                  value={hostAlias}
+                                                >
+                                                  {hostAlias}
+                                                </SelectItem>
+                                              ))}
+                                            </SelectPopup>
+                                          </Select>
+                                        </label>
+
+                                        <label
+                                          htmlFor={`provider-install-ssh-binary-${providerSettings.provider}`}
+                                          className="block"
+                                        >
+                                          <span className="block text-xs font-medium text-foreground">
+                                            {providerSettings.binaryLabel ??
+                                              `${providerSettings.title} binary path`}
+                                          </span>
+                                          <Input
+                                            id={`provider-install-ssh-binary-${providerSettings.provider}`}
+                                            className="mt-1"
+                                            value={selectedRemoteOverride?.binaryPath ?? ""}
+                                            onChange={(event) => {
+                                              if (!selectedRemoteHost) return;
+                                              if (providerSettings.provider === "claudeAgent") {
+                                                updateSettings(
+                                                  buildClaudeHostOverridePatch(
+                                                    settings,
+                                                    { binaryPath: event.target.value },
+                                                    selectedRemoteHost,
+                                                  ),
+                                                );
+                                                return;
+                                              }
+                                              if (providerSettings.provider === "codex") {
+                                                updateSettings(
+                                                  buildCodexHostOverridePatch(
+                                                    settings,
+                                                    { binaryPath: event.target.value },
+                                                    selectedRemoteHost,
+                                                  ),
+                                                );
+                                                return;
+                                              }
+                                              updateSettings(
+                                                buildKiroHostOverridePatch(
+                                                  settings,
+                                                  { binaryPath: event.target.value },
+                                                  selectedRemoteHost,
+                                                ),
+                                              );
+                                            }}
+                                            placeholder={
+                                              providerSettings.provider === "claudeAgent"
+                                                ? "claude"
+                                                : providerSettings.provider === "kiro"
+                                                  ? "kiro-cli"
+                                                  : "codex"
+                                            }
+                                            spellCheck={false}
+                                          />
+                                        </label>
+
+                                        {providerSettings.provider === "codex" ? (
+                                          <label
+                                            htmlFor="provider-install-ssh-home-codex"
+                                            className="block"
+                                          >
+                                            <span className="block text-xs font-medium text-foreground">
+                                              CODEX_HOME path
+                                            </span>
+                                            <Input
+                                              id="provider-install-ssh-home-codex"
+                                              className="mt-1"
+                                              value={selectedCodexRemoteOverride?.homePath ?? ""}
+                                              onChange={(event) => {
+                                                if (!selectedCodexRemoteHost) return;
+                                                updateSettings(
+                                                  buildCodexHostOverridePatch(
+                                                    settings,
+                                                    { homePath: event.target.value },
+                                                    selectedCodexRemoteHost,
+                                                  ),
+                                                );
+                                              }}
+                                              placeholder="/home/you/.codex"
+                                              spellCheck={false}
+                                            />
+                                          </label>
+                                        ) : null}
+                                      </>
+                                    ) : (
+                                      <div className="rounded-lg border border-dashed border-border bg-background px-3 py-4 text-xs text-muted-foreground">
+                                        Open an SSH project to configure per-host{" "}
+                                        {providerSettings.title} overrides.
+                                      </div>
+                                    )
+                                  ) : (
+                                    <>
+                                      <label
+                                        htmlFor={`provider-install-${providerSettings.binaryPathKey}`}
+                                        className="block"
+                                      >
+                                        <span className="block text-xs font-medium text-foreground">
+                                          {providerSettings.binaryLabel ??
+                                            `${providerSettings.title} binary path`}
+                                        </span>
+                                        <Input
+                                          id={`provider-install-${providerSettings.binaryPathKey}`}
+                                          className="mt-1"
+                                          value={binaryPathValue}
+                                          onChange={(event) =>
+                                            updateSettings(
+                                              providerSettings.binaryPathKey === "claudeBinaryPath"
+                                                ? { claudeBinaryPath: event.target.value }
+                                                : providerSettings.binaryPathKey ===
+                                                    "kiroBinaryPath"
+                                                  ? { kiroBinaryPath: event.target.value }
+                                                  : { codexBinaryPath: event.target.value },
+                                            )
+                                          }
+                                          placeholder={providerSettings.binaryPlaceholder}
+                                          spellCheck={false}
+                                        />
+                                        <span className="mt-1 block text-xs text-muted-foreground">
+                                          {providerSettings.binaryDescription}
+                                        </span>
+                                      </label>
+
+                                      {providerSettings.homePathKey ? (
+                                        <label
+                                          htmlFor={`provider-install-${providerSettings.homePathKey}`}
+                                          className="block"
+                                        >
+                                          <span className="block text-xs font-medium text-foreground">
+                                            CODEX_HOME path
+                                          </span>
+                                          <Input
+                                            id={`provider-install-${providerSettings.homePathKey}`}
+                                            className="mt-1"
+                                            value={settings.codexHomePath}
+                                            onChange={(event) =>
+                                              updateSettings({
+                                                codexHomePath: event.target.value,
+                                              })
+                                            }
+                                            placeholder={providerSettings.homePlaceholder}
+                                            spellCheck={false}
+                                          />
+                                          {providerSettings.homeDescription ? (
+                                            <span className="mt-1 block text-xs text-muted-foreground">
+                                              {providerSettings.homeDescription}
+                                            </span>
+                                          ) : null}
+                                        </label>
+                                      ) : null}
+                                    </>
+                                  )}
                                 </div>
                               </div>
                             </CollapsibleContent>
@@ -1324,196 +1694,6 @@ function SettingsRouteView() {
                       );
                     })}
                   </div>
-                </div>
-              </SettingsRow>
-
-              <SettingsRow
-                title="Codex SSH overrides"
-                description="Override the Codex binary and CODEX_HOME for specific SSH hosts. Local installs are configured above."
-                resetAction={
-                  hasSelectedCodexRemoteOverride && selectedCodexRemoteHost ? (
-                    <SettingResetButton
-                      label="codex ssh override"
-                      onClick={() =>
-                        updateSettings(
-                          buildCodexHostOverridePatch(
-                            settings,
-                            {
-                              binaryPath: "",
-                              homePath: "",
-                            },
-                            selectedCodexRemoteHost,
-                          ),
-                        )
-                      }
-                    />
-                  ) : null
-                }
-              >
-                <div className="mt-4 border-t border-border pt-4">
-                  {codexRemoteHosts.length > 0 ? (
-                    <div className="space-y-3">
-                      <label htmlFor="codex-ssh-host" className="block">
-                        <span className="block text-xs font-medium text-foreground">SSH host</span>
-                        <Select
-                          value={selectedCodexRemoteHost ?? ""}
-                          onValueChange={(value) => {
-                            if (typeof value !== "string") return;
-                            if (!codexRemoteHosts.includes(value)) return;
-                            setSelectedCodexRemoteHost(value);
-                          }}
-                        >
-                          <SelectTrigger
-                            id="codex-ssh-host"
-                            className="mt-1 w-full"
-                            aria-label="Codex SSH override host"
-                          >
-                            <SelectValue>{selectedCodexRemoteHost ?? "Select host"}</SelectValue>
-                          </SelectTrigger>
-                          <SelectPopup align="start" alignItemWithTrigger={false}>
-                            {codexRemoteHosts.map((hostAlias) => (
-                              <SelectItem hideIndicator key={hostAlias} value={hostAlias}>
-                                {hostAlias}
-                              </SelectItem>
-                            ))}
-                          </SelectPopup>
-                        </Select>
-                      </label>
-
-                      <label htmlFor="codex-ssh-binary-path" className="block">
-                        <span className="block text-xs font-medium text-foreground">
-                          Codex binary path
-                        </span>
-                        <Input
-                          id="codex-ssh-binary-path"
-                          className="mt-1"
-                          value={selectedCodexRemoteOverride?.binaryPath ?? ""}
-                          onChange={(event) => {
-                            if (!selectedCodexRemoteHost) return;
-                            updateSettings(
-                              buildCodexHostOverridePatch(
-                                settings,
-                                { binaryPath: event.target.value },
-                                selectedCodexRemoteHost,
-                              ),
-                            );
-                          }}
-                          placeholder="codex"
-                          spellCheck={false}
-                        />
-                      </label>
-
-                      <label htmlFor="codex-ssh-home-path" className="block">
-                        <span className="block text-xs font-medium text-foreground">
-                          CODEX_HOME path
-                        </span>
-                        <Input
-                          id="codex-ssh-home-path"
-                          className="mt-1"
-                          value={selectedCodexRemoteOverride?.homePath ?? ""}
-                          onChange={(event) => {
-                            if (!selectedCodexRemoteHost) return;
-                            updateSettings(
-                              buildCodexHostOverridePatch(
-                                settings,
-                                { homePath: event.target.value },
-                                selectedCodexRemoteHost,
-                              ),
-                            );
-                          }}
-                          placeholder="/home/you/.codex"
-                          spellCheck={false}
-                        />
-                      </label>
-                    </div>
-                  ) : (
-                    <div className="rounded-lg border border-dashed border-border bg-background px-3 py-4 text-xs text-muted-foreground">
-                      Open an SSH project to configure per-host Codex overrides.
-                    </div>
-                  )}
-                </div>
-              </SettingsRow>
-
-              <SettingsRow
-                title="Kiro SSH overrides"
-                description="Override the Kiro CLI binary for specific SSH hosts. Local installs are configured above."
-                resetAction={
-                  hasSelectedKiroRemoteOverride && selectedKiroRemoteHost ? (
-                    <SettingResetButton
-                      label="kiro ssh override"
-                      onClick={() =>
-                        updateSettings(
-                          buildKiroHostOverridePatch(
-                            settings,
-                            {
-                              binaryPath: "",
-                            },
-                            selectedKiroRemoteHost,
-                          ),
-                        )
-                      }
-                    />
-                  ) : null
-                }
-              >
-                <div className="mt-4 border-t border-border pt-4">
-                  {kiroRemoteHosts.length > 0 ? (
-                    <div className="space-y-3">
-                      <label htmlFor="kiro-ssh-host" className="block">
-                        <span className="block text-xs font-medium text-foreground">SSH host</span>
-                        <Select
-                          value={selectedKiroRemoteHost ?? ""}
-                          onValueChange={(value) => {
-                            if (typeof value !== "string") return;
-                            if (!kiroRemoteHosts.includes(value)) return;
-                            setSelectedKiroRemoteHost(value);
-                          }}
-                        >
-                          <SelectTrigger
-                            id="kiro-ssh-host"
-                            className="mt-1 w-full"
-                            aria-label="Kiro SSH override host"
-                          >
-                            <SelectValue>{selectedKiroRemoteHost ?? "Select host"}</SelectValue>
-                          </SelectTrigger>
-                          <SelectPopup align="start" alignItemWithTrigger={false}>
-                            {kiroRemoteHosts.map((hostAlias) => (
-                              <SelectItem hideIndicator key={hostAlias} value={hostAlias}>
-                                {hostAlias}
-                              </SelectItem>
-                            ))}
-                          </SelectPopup>
-                        </Select>
-                      </label>
-
-                      <label htmlFor="kiro-ssh-binary-path" className="block">
-                        <span className="block text-xs font-medium text-foreground">
-                          Kiro binary path
-                        </span>
-                        <Input
-                          id="kiro-ssh-binary-path"
-                          className="mt-1"
-                          value={selectedKiroRemoteOverride?.binaryPath ?? ""}
-                          onChange={(event) => {
-                            if (!selectedKiroRemoteHost) return;
-                            updateSettings(
-                              buildKiroHostOverridePatch(
-                                settings,
-                                { binaryPath: event.target.value },
-                                selectedKiroRemoteHost,
-                              ),
-                            );
-                          }}
-                          placeholder="kiro-cli"
-                          spellCheck={false}
-                        />
-                      </label>
-                    </div>
-                  ) : (
-                    <div className="rounded-lg border border-dashed border-border bg-background px-3 py-4 text-xs text-muted-foreground">
-                      Open an SSH project to configure per-host Kiro overrides.
-                    </div>
-                  )}
                 </div>
               </SettingsRow>
 


### PR DESCRIPTION
- Support per-host Claude binary overrides in app settings
- Update provider install UI to switch between local and SSH targets
- Cover the new override flow in settings tests

## What Changed

## Why

## Validation

## Maintenance Impact

## UI Changes

## Checklist
