### PR TITLE
Preserve help interaction mode in draft store

### DIFF
--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -570,6 +570,16 @@ describe("composerDraftStore project draft thread mapping", () => {
     });
   });
 
+  it("preserves help interaction mode in project draft thread metadata", () => {
+    const store = useComposerDraftStore.getState();
+
+    store.setProjectDraftThreadId(projectId, threadId, {
+      interactionMode: "help",
+    });
+
+    expect(useComposerDraftStore.getState().getDraftThread(threadId)?.interactionMode).toBe("help");
+  });
+
   it("preserves existing branch and worktree when setProjectDraftThreadId receives undefined", () => {
     const store = useComposerDraftStore.getState();
     store.setProjectDraftThreadId(projectId, threadId, {
@@ -984,6 +994,16 @@ describe("composerDraftStore runtime and interaction settings", () => {
 
     expect(useComposerDraftStore.getState().draftsByThreadId[threadId]?.interactionMode).toBe(
       "plan",
+    );
+  });
+
+  it("stores help interaction mode overrides in the composer draft", () => {
+    const store = useComposerDraftStore.getState();
+
+    store.setInteractionMode(threadId, "help");
+
+    expect(useComposerDraftStore.getState().draftsByThreadId[threadId]?.interactionMode).toBe(
+      "help",
     );
   });
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -798,6 +798,7 @@ function normalizePersistedDraftThreads(
             : DEFAULT_RUNTIME_MODE,
         interactionMode:
           candidateDraftThread.interactionMode === "plan" ||
+          candidateDraftThread.interactionMode === "help" ||
           candidateDraftThread.interactionMode === "default"
             ? candidateDraftThread.interactionMode
             : DEFAULT_INTERACTION_MODE,
@@ -882,7 +883,9 @@ function normalizePersistedDraftsByThreadId(
         ? draftCandidate.runtimeMode
         : null;
     const interactionMode =
-      draftCandidate.interactionMode === "plan" || draftCandidate.interactionMode === "default"
+      draftCandidate.interactionMode === "plan" ||
+      draftCandidate.interactionMode === "help" ||
+      draftCandidate.interactionMode === "default"
         ? draftCandidate.interactionMode
         : null;
     const prompt = ensureInlineTerminalContextPlaceholders(
@@ -1841,7 +1844,9 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
           return;
         }
         const nextInteractionMode =
-          interactionMode === "plan" || interactionMode === "default" ? interactionMode : null;
+          interactionMode === "plan" || interactionMode === "help" || interactionMode === "default"
+            ? interactionMode
+            : null;
         set((state) => {
           const existing = state.draftsByThreadId[threadId];
           if (!existing && nextInteractionMode === null) {


### PR DESCRIPTION
- Persist `help` interaction mode in normalized draft thread metadata
- Allow `help` overrides to be stored in composer drafts
- Add tests covering help mode round-tripping

## What Changed

Allowed for normlization of the help method

## Why

Kiro CLI enables us to do this

## Validation

## Maintenance Impact

## UI Changes

## Checklist
