### PR TITLE
Add startup messages to provider thread events

### DIFF
--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -742,7 +742,13 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         resolvedThreadId: providerThreadId,
         requestedRuntimeMode: input.runtimeMode,
       }).pipe(this.runPromise);
-      this.emitLifecycleEvent(context, "session/ready", `Connected to thread ${providerThreadId}`);
+      this.emitLifecycleEvent(
+        context,
+        "session/ready",
+        threadOpenMethod === "thread/resume"
+          ? `Reconnected to thread ${providerThreadId}`
+          : `Connected to thread ${providerThreadId}`,
+      );
       return { ...context.session };
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to start Codex session.";

--- a/apps/server/src/kiroAcpManager.ts
+++ b/apps/server/src/kiroAcpManager.ts
@@ -163,6 +163,14 @@ function readResumeSessionId(resumeCursor: unknown): string | undefined {
   );
 }
 
+function kiroSessionStartedMessage(sessionId: string | undefined): string {
+  return sessionId ? `Attempting to resume thread ${sessionId}.` : "Starting a new Kiro thread.";
+}
+
+function kiroThreadConnectedMessage(sessionId: string, resumed: boolean): string {
+  return resumed ? `Reconnected to thread ${sessionId}` : `Connected to thread ${sessionId}`;
+}
+
 function modeTokens(mode: KiroModeDescriptor): string {
   return [mode.id, mode.name, mode.description]
     .filter((value): value is string => typeof value === "string" && value.length > 0)
@@ -656,7 +664,7 @@ export class KiroAcpManager extends EventEmitter {
       this.runtimeEvent(session, {
         type: "session.started",
         payload: {
-          message: "Kiro ACP session started",
+          message: kiroSessionStartedMessage(resumeSessionId),
           resume: resumeCursorFromSessionId(session.sessionId),
         },
       }),
@@ -667,6 +675,7 @@ export class KiroAcpManager extends EventEmitter {
         type: "thread.started",
         payload: {
           providerThreadId: session.sessionId,
+          message: kiroThreadConnectedMessage(session.sessionId, Boolean(resumeSessionId)),
         },
       }),
     );

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -2012,6 +2012,9 @@ describe("ClaudeAdapterLive", () => {
       assert.equal(sessionStarted?.type, "session.started");
       if (sessionStarted?.type === "session.started") {
         assert.equal(sessionStarted.threadId, THREAD_ID);
+        assert.deepEqual(sessionStarted.payload, {
+          message: "Starting a new Claude Code thread.",
+        });
       }
 
       const threadStarted = runtimeEvents[4];
@@ -2020,6 +2023,7 @@ describe("ClaudeAdapterLive", () => {
         assert.equal(threadStarted.threadId, THREAD_ID);
         assert.deepEqual(threadStarted.payload, {
           providerThreadId: "sdk-thread-real",
+          message: "Connected to thread sdk-thread-real",
         });
       }
     }).pipe(

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -219,6 +219,20 @@ function getEffectiveClaudeCodeEffort(
   return effort === "ultrathink" ? null : effort;
 }
 
+function claudeSessionStartedMessage(resumeState: ClaudeResumeState | undefined): string {
+  if (resumeState?.threadId) {
+    return `Attempting to resume thread ${resumeState.threadId}.`;
+  }
+  if (resumeState?.resume) {
+    return "Attempting to resume a Claude Code thread.";
+  }
+  return "Starting a new Claude Code thread.";
+}
+
+function claudeThreadConnectedMessage(providerThreadId: string): string {
+  return `Connected to thread ${providerThreadId}`;
+}
+
 function isClaudeInterruptedMessage(message: string): boolean {
   const normalized = message.toLowerCase();
   return (
@@ -1256,6 +1270,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             threadId: context.session.threadId,
             payload: {
               providerThreadId: nextThreadId,
+              message: claudeThreadConnectedMessage(nextThreadId),
             },
             providerRefs: {},
             raw: {
@@ -2834,7 +2849,10 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           provider: PROVIDER,
           createdAt: sessionStartedStamp.createdAt,
           threadId,
-          payload: input.resumeCursor !== undefined ? { resume: input.resumeCursor } : {},
+          payload: {
+            message: claudeSessionStartedMessage(resumeState),
+            ...(input.resumeCursor !== undefined ? { resume: input.resumeCursor } : {}),
+          },
           providerRefs: {},
         });
 

--- a/packages/contracts/src/providerRuntime.test.ts
+++ b/packages/contracts/src/providerRuntime.test.ts
@@ -164,4 +164,25 @@ describe("ProviderRuntimeEvent", () => {
     expect(parsed.payload.usage.maxTokens).toBe(200000);
     expect(parsed.payload.usage.usedTokens).toBe(31251);
   });
+
+  it("decodes thread.started messages alongside provider thread ids", () => {
+    const parsed = decodeRuntimeEvent({
+      type: "thread.started",
+      eventId: "event-thread-started-1",
+      provider: "kiro",
+      createdAt: "2026-02-28T00:00:05.000Z",
+      threadId: "thread-1",
+      payload: {
+        providerThreadId: "provider-thread-1",
+        message: "Reconnected to thread provider-thread-1",
+      },
+    });
+
+    expect(parsed.type).toBe("thread.started");
+    if (parsed.type !== "thread.started") {
+      throw new Error("expected thread.started");
+    }
+    expect(parsed.payload.providerThreadId).toBe("provider-thread-1");
+    expect(parsed.payload.message).toBe("Reconnected to thread provider-thread-1");
+  });
 });

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -273,6 +273,7 @@ export type SessionExitedPayload = typeof SessionExitedPayload.Type;
 
 const ThreadStartedPayload = Schema.Struct({
   providerThreadId: Schema.optional(TrimmedNonEmptyStringSchema),
+  message: Schema.optional(TrimmedNonEmptyStringSchema),
 });
 export type ThreadStartedPayload = typeof ThreadStartedPayload.Type;
 


### PR DESCRIPTION
- Distinguish new sessions from resumes in session/thread lifecycle logs
- Extend thread.started payloads with optional messages and update tests

## What Changed

Added some logging to the Kiro CLI and the Codex Implementation 

## Why

Thread management is becomming a pain to debug

## Validation

## Maintenance Impact

## UI Changes

## Checklist
