### PR TITLE
Use resolved model selection for git actions

### DIFF
--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -318,7 +318,7 @@ export function buildGitRequestSettings(
     | "customClaudeModels"
     | "customKiroModels"
   >,
-): GitRequestSettings | undefined {
+): GitRequestSettings {
   const githubBinaryPath = settings.gitHubBinaryPath.trim();
   const commitPrompt = settings.gitCommitPrompt.trim();
   const textGenerationModelSelection = resolveAppModelSelectionState(settings);

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -9,6 +9,7 @@ import { useIsMutating, useMutation, useQuery, useQueryClient } from "@tanstack/
 import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 import { ChevronDownIcon, CloudUploadIcon, GitCommitIcon, InfoIcon } from "lucide-react";
 import { buildGitRequestSettings, useAppSettings } from "../appSettings";
+import { resolveAppModelSelectionState } from "../modelSelection";
 import { GitHubIcon } from "./Icons";
 import {
   buildGitActionProgressStages,
@@ -226,6 +227,11 @@ export default function GitActionsControl({
   const [pendingDefaultBranchAction, setPendingDefaultBranchAction] =
     useState<PendingDefaultBranchAction | null>(null);
   const gitRequestSettings = useMemo(() => buildGitRequestSettings(settings), [settings]);
+  const gitActionModelSelection = useMemo(
+    () =>
+      gitRequestSettings.textGenerationModelSelection ?? resolveAppModelSelectionState(settings),
+    [gitRequestSettings.textGenerationModelSelection, settings],
+  );
   const activeGitActionProgressRef = useRef<ActiveGitActionProgress | null>(null);
 
   const updateActiveProgressToast = useCallback(() => {
@@ -273,7 +279,7 @@ export default function GitActionsControl({
       target: gitTarget,
       queryClient,
       ...(gitRequestSettings ? { settings: gitRequestSettings } : {}),
-      modelSelection: settings.textGenerationModelSelection,
+      modelSelection: gitActionModelSelection,
     }),
   );
   const pullMutation = useMutation(gitPullMutationOptions({ target: gitTarget, queryClient }));


### PR DESCRIPTION
- Keep git request settings non-optional
- Fall back to resolved app model selection when building git actions

## What Changed

## Why

## Validation

## Maintenance Impact

## UI Changes

## Checklist
