### PR TITLE
Isolate thread reactor workers to prevent head-of-line blocking

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -64,6 +64,18 @@ async function waitFor(
 }
 
 describe("ProviderCommandReactor", () => {
+  type HarnessOptions = {
+    readonly baseDir?: string;
+    readonly threadModelSelection?: ModelSelection;
+    readonly sessionModelSwitch?: "unsupported" | "in-session";
+    readonly projectWorkspaceRoot?: string;
+    readonly projectRemote?: { readonly kind: "ssh"; readonly hostAlias: string } | null;
+    readonly startSessionImplementation?: (
+      input: unknown,
+      session: ProviderSession,
+    ) => Effect.Effect<ProviderSession>;
+  };
+
   let runtime: ManagedRuntime.ManagedRuntime<
     OrchestrationEngineService | ProviderCommandReactor,
     unknown
@@ -91,13 +103,7 @@ describe("ProviderCommandReactor", () => {
     createdBaseDirs.clear();
   });
 
-  async function createHarness(input?: {
-    readonly baseDir?: string;
-    readonly threadModelSelection?: ModelSelection;
-    readonly sessionModelSwitch?: "unsupported" | "in-session";
-    readonly projectWorkspaceRoot?: string;
-    readonly projectRemote?: { readonly kind: "ssh"; readonly hostAlias: string } | null;
-  }) {
+  async function createHarness(input?: HarnessOptions) {
     const now = new Date().toISOString();
     const baseDir = input?.baseDir ?? fs.mkdtempSync(path.join(os.tmpdir(), "t3code-reactor-"));
     createdBaseDirs.add(baseDir);
@@ -110,28 +116,32 @@ describe("ProviderCommandReactor", () => {
       provider: "codex",
       model: "gpt-5-codex",
     };
-    const startSession = vi.fn((_: unknown, input: unknown) => {
+    const startSessionImplementation: NonNullable<HarnessOptions["startSessionImplementation"]> =
+      input?.startSessionImplementation ??
+      ((_: unknown, session: ProviderSession) => Effect.succeed(session));
+    const startSession = vi.fn((_: unknown, startInput: unknown) => {
       const sessionIndex = nextSessionIndex++;
       const resumeCursor =
-        typeof input === "object" && input !== null && "resumeCursor" in input
-          ? input.resumeCursor
+        typeof startInput === "object" && startInput !== null && "resumeCursor" in startInput
+          ? startInput.resumeCursor
           : undefined;
       const threadId =
-        typeof input === "object" &&
-        input !== null &&
-        "threadId" in input &&
-        typeof input.threadId === "string"
-          ? ThreadId.makeUnsafe(input.threadId)
+        typeof startInput === "object" &&
+        startInput !== null &&
+        "threadId" in startInput &&
+        typeof startInput.threadId === "string"
+          ? ThreadId.makeUnsafe(startInput.threadId)
           : ThreadId.makeUnsafe(`thread-${sessionIndex}`);
       const session: ProviderSession = {
         provider: modelSelection.provider,
         status: "ready" as const,
         runtimeMode:
-          typeof input === "object" &&
-          input !== null &&
-          "runtimeMode" in input &&
-          (input.runtimeMode === "approval-required" || input.runtimeMode === "full-access")
-            ? input.runtimeMode
+          typeof startInput === "object" &&
+          startInput !== null &&
+          "runtimeMode" in startInput &&
+          (startInput.runtimeMode === "approval-required" ||
+            startInput.runtimeMode === "full-access")
+            ? startInput.runtimeMode
             : "full-access",
         ...(modelSelection.model !== undefined ? { model: modelSelection.model } : {}),
         threadId,
@@ -139,8 +149,13 @@ describe("ProviderCommandReactor", () => {
         createdAt: now,
         updatedAt: now,
       };
-      runtimeSessions.push(session);
-      return Effect.succeed(session);
+      return startSessionImplementation(startInput, session).pipe(
+        Effect.tap((resolvedSession) =>
+          Effect.sync(() => {
+            runtimeSessions.push(resolvedSession);
+          }),
+        ),
+      );
     });
     const sendTurn = vi.fn((_: unknown) =>
       Effect.succeed({
@@ -308,6 +323,96 @@ describe("ProviderCommandReactor", () => {
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"));
     expect(thread?.session?.threadId).toBe("thread-1");
     expect(thread?.session?.runtimeMode).toBe("approval-required");
+  });
+
+  it("does not let one hung thread start block another thread", async () => {
+    const harness = await createHarness({
+      startSessionImplementation: (input, session) => {
+        const threadId =
+          typeof input === "object" &&
+          input !== null &&
+          "threadId" in input &&
+          typeof input.threadId === "string"
+            ? input.threadId
+            : null;
+        return threadId === "thread-1" ? Effect.never : Effect.succeed(session);
+      },
+    });
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.makeUnsafe("cmd-thread-create-2"),
+        threadId: ThreadId.makeUnsafe("thread-2"),
+        projectId: asProjectId("project-1"),
+        title: "Thread 2",
+        modelSelection: {
+          provider: "codex",
+          model: "gpt-5-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        branch: null,
+        worktreePath: null,
+        createdAt: now,
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-hung-thread-1"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-hung-thread-1"),
+          role: "user",
+          text: "thread one hangs on start",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-hung-thread-2"),
+        threadId: ThreadId.makeUnsafe("thread-2"),
+        message: {
+          messageId: asMessageId("user-message-hung-thread-2"),
+          role: "user",
+          text: "thread two should still run",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length >= 2);
+    await waitFor(() =>
+      harness.sendTurn.mock.calls.some(
+        ([payload]) =>
+          typeof payload === "object" &&
+          payload !== null &&
+          "threadId" in payload &&
+          payload.threadId === ThreadId.makeUnsafe("thread-2"),
+      ),
+    );
+
+    expect(
+      harness.sendTurn.mock.calls.some(
+        ([payload]) =>
+          typeof payload === "object" &&
+          payload !== null &&
+          "threadId" in payload &&
+          payload.threadId === ThreadId.makeUnsafe("thread-1"),
+      ),
+    ).toBe(false);
   });
 
   it("uses git text-generation settings when renaming a first-turn worktree branch", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -16,7 +16,7 @@ import {
   type TurnId,
 } from "@t3tools/contracts";
 import { Cache, Cause, Duration, Effect, Equal, Layer, Option, Schema, Stream } from "effect";
-import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
+import { type DrainableWorker, makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 
 import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
 import { GitCore } from "../../git/Services/GitCore.ts";
@@ -809,7 +809,19 @@ const make = Effect.gen(function* () {
       }),
     );
 
-  const worker = yield* makeDrainableWorker(processDomainEventSafely);
+  const workersByThreadId = new Map<ThreadId, DrainableWorker<ProviderIntentEvent>>();
+
+  const workerForThread = (threadId: ThreadId) =>
+    Effect.gen(function* () {
+      const existing = workersByThreadId.get(threadId);
+      if (existing) {
+        return existing;
+      }
+
+      const created = yield* makeDrainableWorker(processDomainEventSafely);
+      workersByThreadId.set(threadId, created);
+      return created;
+    });
 
   const start: ProviderCommandReactorShape["start"] = Effect.forkScoped(
     Stream.runForEach(orchestrationEngine.streamDomainEvents, (event) => {
@@ -824,13 +836,21 @@ const make = Effect.gen(function* () {
         return Effect.void;
       }
 
-      return worker.enqueue(event);
+      return workerForThread(event.payload.threadId).pipe(
+        Effect.flatMap((worker) => worker.enqueue(event)),
+      );
     }),
   ).pipe(Effect.asVoid);
 
   return {
     start,
-    drain: worker.drain,
+    drain: Effect.gen(function* () {
+      const workers = Array.from(workersByThreadId.values());
+      yield* Effect.forEach(workers, (worker) => worker.drain, {
+        concurrency: "unbounded",
+        discard: true,
+      });
+    }),
   } satisfies ProviderCommandReactorShape;
 });
 


### PR DESCRIPTION
- Route provider intents through per-thread drainable workers
- Add a regression test covering a hung thread start alongside a healthy thread

## What Changed
Switches from a global sink to a per thread since

## Why

If a provider is bad, I can't start new thread like in #33 

## Validation

## Maintenance Impact

## UI Changes

## Checklist
