### PR TITLE
gitRepo and gitMode support for Multi Repo Project Support

### DIFF
--- a/apps/server/src/checkpointing/Utils.ts
+++ b/apps/server/src/checkpointing/Utils.ts
@@ -24,5 +24,6 @@ export function resolveThreadWorkspaceCwd(input: {
     return worktreeCwd;
   }
 
-  return input.projects.find((project) => project.id === input.thread.projectId)?.workspaceRoot;
+  const project = input.projects.find((entry) => entry.id === input.thread.projectId);
+  return project?.workspaceRoot;
 }

--- a/apps/server/src/git/projectRepos.ts
+++ b/apps/server/src/git/projectRepos.ts
@@ -1,0 +1,175 @@
+import path from "node:path";
+
+import type { ProjectGitMode, ProjectGitRepo, ProjectRemoteTarget } from "@t3tools/contracts";
+
+import { runProcess } from "../processRunner";
+import { buildSshExecArgs, quotePosixShell } from "../sshCommand";
+
+const CACHE_TTL_MS = 10_000;
+
+export interface DiscoveredProjectRepos {
+  readonly gitMode: ProjectGitMode;
+  readonly gitRepos: ProjectGitRepo[] | null;
+}
+
+type CacheEntry = {
+  readonly readAt: number;
+  readonly value: DiscoveredProjectRepos;
+};
+
+const discoveryCache = new Map<string, CacheEntry>();
+
+function cacheKey(workspaceRoot: string, remote?: ProjectRemoteTarget | null): string {
+  return `${remote?.kind === "ssh" ? `ssh:${remote.hostAlias}` : "local"}\u0000${workspaceRoot}`;
+}
+
+async function isLocalRepoRoot(workspaceRoot: string): Promise<boolean> {
+  try {
+    const result = await runProcess("git", ["-C", workspaceRoot, "rev-parse", "--show-toplevel"], {
+      cwd: workspaceRoot,
+      timeoutMs: 5_000,
+      outputMode: "truncate",
+    });
+    return result.stdout.trim() === workspaceRoot;
+  } catch {
+    return false;
+  }
+}
+
+async function discoverLocalProjectRepos(workspaceRoot: string): Promise<DiscoveredProjectRepos> {
+  if (await isLocalRepoRoot(workspaceRoot)) {
+    return { gitMode: "single", gitRepos: null };
+  }
+
+  let children: string[] = [];
+  try {
+    children = await (await import("node:fs/promises")).readdir(workspaceRoot);
+  } catch {
+    return { gitMode: "none", gitRepos: null };
+  }
+
+  const repos: ProjectGitRepo[] = [];
+  for (const child of children) {
+    const absolutePath = path.join(workspaceRoot, child);
+    try {
+      const stat = await (await import("node:fs/promises")).stat(absolutePath);
+      if (!stat.isDirectory()) continue;
+      const result = await runProcess("git", ["-C", absolutePath, "rev-parse", "--show-toplevel"], {
+        cwd: workspaceRoot,
+        timeoutMs: 5_000,
+        outputMode: "truncate",
+      }).catch(() => null);
+      if (!result) continue;
+      if (result.stdout.trim() !== absolutePath) continue;
+      repos.push({
+        repoPath: child,
+        displayName: child,
+      });
+    } catch {
+      continue;
+    }
+  }
+
+  return repos.length > 0
+    ? { gitMode: "multi", gitRepos: repos }
+    : { gitMode: "none", gitRepos: null };
+}
+
+function buildRemoteDiscoveryScript(workspaceRoot: string): string {
+  const escapedWorkspaceRoot = quotePosixShell(workspaceRoot.trim());
+  return [
+    `input_path=${escapedWorkspaceRoot}`,
+    'case "$input_path" in',
+    '  "~") target_path=$HOME ;;',
+    '  "~/"*) target_path=$HOME/${input_path#~/} ;;',
+    "  *) target_path=$input_path ;;",
+    "esac",
+    'cd "$target_path" || exit 12',
+    "resolved_path=$(pwd -P 2>/dev/null || pwd)",
+    'root_repo=$(git -C "$resolved_path" rev-parse --show-toplevel 2>/dev/null || printf "")',
+    'if [ "$root_repo" = "$resolved_path" ]; then',
+    "  printf 'single\\0'",
+    "  exit 0",
+    "fi",
+    "found=0",
+    'for child_path in "$resolved_path"/*; do',
+    '  [ -d "$child_path" ] || continue',
+    "  child_name=${child_path##*/}",
+    '  child_repo=$(git -C "$child_path" rev-parse --show-toplevel 2>/dev/null || printf "")',
+    '  if [ "$child_repo" = "$child_path" ]; then',
+    '    if [ "$found" = "0" ]; then printf "multi\\0"; found=1; fi',
+    '    printf "%s\\0%s\\0" "$child_name" "$child_name"',
+    "  fi",
+    "done",
+    'if [ "$found" = "0" ]; then printf "none\\0"; fi',
+  ].join("\n");
+}
+
+async function discoverRemoteProjectRepos(
+  workspaceRoot: string,
+  remote: ProjectRemoteTarget,
+): Promise<DiscoveredProjectRepos> {
+  try {
+    const result = await runProcess(
+      "ssh",
+      buildSshExecArgs({
+        hostAlias: remote.hostAlias,
+        command: "sh",
+        args: ["-lc", buildRemoteDiscoveryScript(workspaceRoot)],
+        localCwd: process.cwd(),
+      }),
+      {
+        cwd: process.cwd(),
+        timeoutMs: 10_000,
+        outputMode: "truncate",
+      },
+    );
+
+    const parts = result.stdout.split("\0").filter((part) => part.length > 0);
+    const mode = parts[0];
+    if (mode === "single") {
+      return { gitMode: "single", gitRepos: null };
+    }
+    if (mode !== "multi") {
+      return { gitMode: "none", gitRepos: null };
+    }
+
+    const repos: ProjectGitRepo[] = [];
+    for (let index = 1; index + 1 < parts.length; index += 2) {
+      repos.push({
+        repoPath: parts[index]!,
+        displayName: parts[index + 1]!,
+      });
+    }
+    return repos.length > 0
+      ? { gitMode: "multi", gitRepos: repos }
+      : { gitMode: "none", gitRepos: null };
+  } catch {
+    return { gitMode: "none", gitRepos: null };
+  }
+}
+
+export async function discoverProjectRepos(input: {
+  readonly workspaceRoot: string;
+  readonly remote?: ProjectRemoteTarget | null;
+}): Promise<DiscoveredProjectRepos> {
+  const key = cacheKey(input.workspaceRoot, input.remote ?? null);
+  const cached = discoveryCache.get(key);
+  if (cached && Date.now() - cached.readAt < CACHE_TTL_MS) {
+    return cached.value;
+  }
+
+  const value =
+    input.remote?.kind === "ssh"
+      ? await discoverRemoteProjectRepos(input.workspaceRoot, input.remote)
+      : await discoverLocalProjectRepos(input.workspaceRoot);
+  discoveryCache.set(key, { readAt: Date.now(), value });
+  return value;
+}
+
+export function clearProjectRepoDiscoveryCache(input: {
+  readonly workspaceRoot: string;
+  readonly remote?: ProjectRemoteTarget | null;
+}): void {
+  discoveryCache.delete(cacheKey(input.workspaceRoot, input.remote ?? null));
+}

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -365,6 +365,8 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
             remote: event.payload.remote ?? null,
             defaultModelSelection: event.payload.defaultModelSelection,
             scripts: event.payload.scripts,
+            gitMode: event.payload.gitMode,
+            gitRepos: event.payload.gitRepos,
             createdAt: event.payload.createdAt,
             updatedAt: event.payload.updatedAt,
             deletedAt: null,
@@ -389,6 +391,8 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
               ? { defaultModelSelection: event.payload.defaultModelSelection }
               : {}),
             ...(event.payload.scripts !== undefined ? { scripts: event.payload.scripts } : {}),
+            ...(event.payload.gitMode !== undefined ? { gitMode: event.payload.gitMode } : {}),
+            ...(event.payload.gitRepos !== undefined ? { gitRepos: event.payload.gitRepos } : {}),
             updatedAt: event.payload.updatedAt,
           });
           return;

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -6,6 +6,7 @@ import {
   OrchestrationCheckpointFile,
   OrchestrationProposedPlanId,
   OrchestrationReadModel,
+  ProjectGitRepo,
   ProjectRemoteTarget,
   ProjectScript,
   ThreadId,
@@ -40,6 +41,7 @@ import { ProjectionThreadProposedPlan } from "../../persistence/Services/Project
 import { ProjectionThreadSession } from "../../persistence/Services/ProjectionThreadSessions.ts";
 import { ProjectionThread } from "../../persistence/Services/ProjectionThreads.ts";
 import { readPersistedRemoteSessionMetadata } from "../../provider/remoteSessionMetadata.ts";
+import { discoverProjectRepos } from "../../git/projectRepos.ts";
 import { ORCHESTRATION_PROJECTOR_NAMES } from "./ProjectionPipeline.ts";
 import {
   ProjectionSnapshotQuery,
@@ -52,6 +54,7 @@ const ProjectionProjectDbRowSchema = ProjectionProject.mapFields(
     defaultModelSelection: Schema.NullOr(Schema.fromJsonString(ModelSelection)),
     scripts: Schema.fromJsonString(Schema.Array(ProjectScript)),
     remote: Schema.NullOr(Schema.fromJsonString(ProjectRemoteTarget)),
+    gitRepos: Schema.NullOr(Schema.fromJsonString(Schema.Array(ProjectGitRepo))),
   }),
 );
 const ProjectionThreadMessageDbRowSchema = ProjectionThreadMessage.mapFields(
@@ -256,6 +259,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           remote_json AS "remote",
           default_model_selection_json AS "defaultModelSelection",
           scripts_json AS "scripts",
+          git_mode AS "gitMode",
+          git_repos_json AS "gitRepos",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
           deleted_at AS "deletedAt"
@@ -680,17 +685,36 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             updatedAt = maxIso(updatedAt, row.lastSeenAt);
           }
 
-          const projects: ReadonlyArray<OrchestrationProject> = projectRows.map((row) => ({
-            id: row.projectId,
-            title: row.title,
-            workspaceRoot: row.workspaceRoot,
-            remote: row.remote,
-            defaultModelSelection: row.defaultModelSelection,
-            scripts: row.scripts,
-            createdAt: row.createdAt,
-            updatedAt: row.updatedAt,
-            deletedAt: row.deletedAt,
-          }));
+          const projects: ReadonlyArray<OrchestrationProject> = yield* Effect.forEach(
+            projectRows,
+            (row) =>
+              Effect.tryPromise({
+                try: () =>
+                  discoverProjectRepos({
+                    workspaceRoot: row.workspaceRoot,
+                    remote: row.remote,
+                  }),
+                catch: () => ({
+                  gitMode: row.gitMode ?? "none",
+                  gitRepos: row.gitRepos ?? null,
+                }),
+              }).pipe(
+                Effect.map((discovery) => ({
+                  id: row.projectId,
+                  title: row.title,
+                  workspaceRoot: row.workspaceRoot,
+                  remote: row.remote,
+                  defaultModelSelection: row.defaultModelSelection,
+                  scripts: row.scripts,
+                  gitMode: discovery.gitMode,
+                  gitRepos: discovery.gitRepos,
+                  createdAt: row.createdAt,
+                  updatedAt: row.updatedAt,
+                  deletedAt: row.deletedAt,
+                })),
+              ),
+            { concurrency: 4 },
+          );
           const projectsById = new Map(projects.map((project) => [project.id, project] as const));
 
           const threads: ReadonlyArray<OrchestrationThread> = threadRows.map((row) => ({

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -310,8 +310,8 @@ const make = Effect.gen(function* () {
       thread,
       projects: readModel.projects,
     });
-    const projectRemote =
-      readModel.projects.find((project) => project.id === thread.projectId)?.remote ?? null;
+    const project = readModel.projects.find((entry) => entry.id === thread.projectId) ?? null;
+    const projectRemote = project?.remote ?? null;
     const effectiveProviderOptions = resolveProjectScopedProviderOptions({
       ...(preferredProvider !== undefined ? { provider: preferredProvider } : {}),
       ...(options?.providerOptions !== undefined

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -582,7 +582,10 @@ const make = Effect.gen(function* () {
     if (!project) {
       return false;
     }
-    const workspaceCwd = thread.worktreePath ?? project.workspaceRoot;
+    const workspaceCwd = resolveThreadWorkspaceCwd({
+      thread,
+      projects: [project],
+    });
     if (!workspaceCwd) {
       return false;
     }

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -80,6 +80,8 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           remote: command.remote,
           defaultModelSelection: command.defaultModelSelection ?? null,
           scripts: [],
+          gitMode: "none",
+          gitRepos: null,
           createdAt: command.createdAt,
           updatedAt: command.createdAt,
         },
@@ -110,6 +112,8 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
             ? { defaultModelSelection: command.defaultModelSelection }
             : {}),
           ...(command.scripts !== undefined ? { scripts: command.scripts } : {}),
+          ...(command.gitMode !== undefined ? { gitMode: command.gitMode } : {}),
+          ...(command.gitRepos !== undefined ? { gitRepos: command.gitRepos } : {}),
           updatedAt: occurredAt,
         },
       };

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -185,6 +185,8 @@ export function projectEvent(
             ...(payload.remote !== undefined ? { remote: payload.remote } : {}),
             defaultModelSelection: payload.defaultModelSelection,
             scripts: payload.scripts,
+            gitMode: payload.gitMode,
+            gitRepos: payload.gitRepos,
             createdAt: payload.createdAt,
             updatedAt: payload.updatedAt,
             deletedAt: null,
@@ -218,6 +220,8 @@ export function projectEvent(
                     ? { defaultModelSelection: payload.defaultModelSelection }
                     : {}),
                   ...(payload.scripts !== undefined ? { scripts: payload.scripts } : {}),
+                  ...(payload.gitMode !== undefined ? { gitMode: payload.gitMode } : {}),
+                  ...(payload.gitRepos !== undefined ? { gitRepos: payload.gitRepos } : {}),
                   updatedAt: payload.updatedAt,
                 }
               : project,

--- a/apps/server/src/persistence/Layers/ProjectionProjects.ts
+++ b/apps/server/src/persistence/Layers/ProjectionProjects.ts
@@ -2,7 +2,13 @@ import * as SqlClient from "effect/unstable/sql/SqlClient";
 import * as SqlSchema from "effect/unstable/sql/SqlSchema";
 import { Effect, Layer, Schema, Struct } from "effect";
 
-import { ModelSelection, ProjectRemoteTarget, ProjectScript } from "@t3tools/contracts";
+import {
+  ModelSelection,
+  ProjectGitMode,
+  ProjectGitRepo,
+  ProjectRemoteTarget,
+  ProjectScript,
+} from "@t3tools/contracts";
 import { toPersistenceSqlError } from "../Errors.ts";
 import {
   DeleteProjectionProjectInput,
@@ -16,6 +22,8 @@ const ProjectionProjectDbRow = ProjectionProject.mapFields(
     defaultModelSelection: Schema.NullOr(Schema.fromJsonString(ModelSelection)),
     scripts: Schema.fromJsonString(Schema.Array(ProjectScript)),
     remote: Schema.NullOr(Schema.fromJsonString(ProjectRemoteTarget)),
+    gitRepos: Schema.NullOr(Schema.fromJsonString(Schema.Array(ProjectGitRepo))),
+    gitMode: ProjectGitMode,
   }),
 );
 type ProjectionProjectDbRow = typeof ProjectionProjectDbRow.Type;
@@ -34,6 +42,8 @@ const makeProjectionProjectRepository = Effect.gen(function* () {
           remote_json,
           default_model_selection_json,
           scripts_json,
+          git_mode,
+          git_repos_json,
           created_at,
           updated_at,
           deleted_at
@@ -45,6 +55,8 @@ const makeProjectionProjectRepository = Effect.gen(function* () {
           ${row.remote !== null ? JSON.stringify(row.remote) : null},
           ${row.defaultModelSelection !== null ? JSON.stringify(row.defaultModelSelection) : null},
           ${JSON.stringify(row.scripts)},
+          ${row.gitMode ?? "none"},
+          ${row.gitRepos !== null && row.gitRepos !== undefined ? JSON.stringify(row.gitRepos) : null},
           ${row.createdAt},
           ${row.updatedAt},
           ${row.deletedAt}
@@ -56,6 +68,8 @@ const makeProjectionProjectRepository = Effect.gen(function* () {
           remote_json = excluded.remote_json,
           default_model_selection_json = excluded.default_model_selection_json,
           scripts_json = excluded.scripts_json,
+          git_mode = excluded.git_mode,
+          git_repos_json = excluded.git_repos_json,
           created_at = excluded.created_at,
           updated_at = excluded.updated_at,
           deleted_at = excluded.deleted_at
@@ -74,6 +88,8 @@ const makeProjectionProjectRepository = Effect.gen(function* () {
           remote_json AS "remote",
           default_model_selection_json AS "defaultModelSelection",
           scripts_json AS "scripts",
+          git_mode AS "gitMode",
+          git_repos_json AS "gitRepos",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
           deleted_at AS "deletedAt"
@@ -94,6 +110,8 @@ const makeProjectionProjectRepository = Effect.gen(function* () {
           remote_json AS "remote",
           default_model_selection_json AS "defaultModelSelection",
           scripts_json AS "scripts",
+          git_mode AS "gitMode",
+          git_repos_json AS "gitRepos",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
           deleted_at AS "deletedAt"

--- a/apps/server/src/persistence/Migrations/019_MultiRepoProjectionState.ts
+++ b/apps/server/src/persistence/Migrations/019_MultiRepoProjectionState.ts
@@ -1,0 +1,16 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    ALTER TABLE projection_projects
+    ADD COLUMN git_mode TEXT NOT NULL DEFAULT 'none'
+  `;
+
+  yield* sql`
+    ALTER TABLE projection_projects
+    ADD COLUMN git_repos_json TEXT
+  `;
+});

--- a/apps/server/src/persistence/Services/ProjectionProjects.ts
+++ b/apps/server/src/persistence/Services/ProjectionProjects.ts
@@ -9,6 +9,8 @@
 import {
   IsoDateTime,
   ModelSelection,
+  ProjectGitMode,
+  ProjectGitRepo,
   ProjectId,
   ProjectRemoteTarget,
   ProjectScript,
@@ -25,6 +27,8 @@ export const ProjectionProject = Schema.Struct({
   remote: Schema.NullOr(ProjectRemoteTarget),
   defaultModelSelection: Schema.NullOr(ModelSelection),
   scripts: Schema.Array(ProjectScript),
+  gitMode: Schema.optional(ProjectGitMode),
+  gitRepos: Schema.optional(Schema.NullOr(Schema.Array(ProjectGitRepo))),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
   deletedAt: Schema.NullOr(IsoDateTime),

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -963,6 +963,18 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
     return project.remote ?? null;
   });
 
+  const ensureMultiRepoGitDisabled = Effect.fnUntraced(function* (projectId?: ProjectId) {
+    if (!projectId) {
+      return;
+    }
+    const project = yield* resolveProject(projectId);
+    if (project.gitMode === "multi") {
+      return yield* new RouteRequestError({
+        message: "Git operations are disabled for multi-repo projects right now.",
+      });
+    }
+  });
+
   const resolveLocalProjectWorkspaceRoot = Effect.fnUntraced(function* (input: {
     readonly projectId: ProjectId;
     readonly operation: string;
@@ -1202,6 +1214,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
 
       case WS_METHODS.gitStatus: {
         const body = stripRequestTag(request.body);
+        yield* ensureMultiRepoGitDisabled(body.projectId);
         const remote = yield* resolveProjectRemote(body.projectId);
         return yield* gitManager.status({
           ...body,
@@ -1211,12 +1224,14 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
 
       case WS_METHODS.gitPull: {
         const body = stripRequestTag(request.body);
+        yield* ensureMultiRepoGitDisabled(body.projectId);
         const remote = yield* resolveProjectRemote(body.projectId);
         return yield* git.pullCurrentBranch(body.cwd, remote);
       }
 
       case WS_METHODS.gitRunStackedAction: {
         const body = stripRequestTag(request.body);
+        yield* ensureMultiRepoGitDisabled(body.projectId);
         const remote = yield* resolveProjectRemote(body.projectId);
         return yield* gitManager.runStackedAction(
           {
@@ -1235,6 +1250,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
 
       case WS_METHODS.gitResolvePullRequest: {
         const body = stripRequestTag(request.body);
+        yield* ensureMultiRepoGitDisabled(body.projectId);
         const remote = yield* resolveProjectRemote(body.projectId);
         return yield* gitManager.resolvePullRequest({
           ...body,
@@ -1244,6 +1260,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
 
       case WS_METHODS.gitPreparePullRequestThread: {
         const body = stripRequestTag(request.body);
+        yield* ensureMultiRepoGitDisabled(body.projectId);
         const remote = yield* resolveProjectRemote(body.projectId);
         return yield* gitManager.preparePullRequestThread({
           ...body,
@@ -1253,6 +1270,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
 
       case WS_METHODS.gitListBranches: {
         const body = stripRequestTag(request.body);
+        yield* ensureMultiRepoGitDisabled(body.projectId);
         const remote = yield* resolveProjectRemote(body.projectId);
         return yield* git.listBranches({
           ...body,
@@ -1262,6 +1280,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
 
       case WS_METHODS.gitCreateWorktree: {
         const body = stripRequestTag(request.body);
+        yield* ensureMultiRepoGitDisabled(body.projectId);
         const remote = yield* resolveProjectRemote(body.projectId);
         return yield* git.createWorktree({
           ...body,
@@ -1271,6 +1290,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
 
       case WS_METHODS.gitRemoveWorktree: {
         const body = stripRequestTag(request.body);
+        yield* ensureMultiRepoGitDisabled(body.projectId);
         const remote = yield* resolveProjectRemote(body.projectId);
         return yield* git.removeWorktree({
           ...body,
@@ -1280,6 +1300,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
 
       case WS_METHODS.gitCreateBranch: {
         const body = stripRequestTag(request.body);
+        yield* ensureMultiRepoGitDisabled(body.projectId);
         const remote = yield* resolveProjectRemote(body.projectId);
         return yield* git.createBranch({
           ...body,
@@ -1289,6 +1310,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
 
       case WS_METHODS.gitCheckout: {
         const body = stripRequestTag(request.body);
+        yield* ensureMultiRepoGitDisabled(body.projectId);
         const remote = yield* resolveProjectRemote(body.projectId);
         return yield* Effect.scoped(
           git.checkoutBranch({
@@ -1300,6 +1322,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
 
       case WS_METHODS.gitInit: {
         const body = stripRequestTag(request.body);
+        yield* ensureMultiRepoGitDisabled(body.projectId);
         const remote = yield* resolveProjectRemote(body.projectId);
         return yield* git.initRepo({
           ...body,

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -51,7 +51,8 @@ export default function BranchToolbar({
   const activeThreadId = serverThread?.id ?? (draftThread ? threadId : undefined);
   const activeThreadBranch = serverThread?.branch ?? draftThread?.branch ?? null;
   const activeWorktreePath = serverThread?.worktreePath ?? draftThread?.worktreePath ?? null;
-  const branchCwd = activeWorktreePath ?? activeProject?.cwd ?? null;
+  const isMultiRepo = activeProject?.gitMode === "multi";
+  const branchCwd = isMultiRepo ? null : (activeWorktreePath ?? activeProject?.cwd ?? null);
   const hasServerThread = serverThread !== undefined;
   const effectiveEnvMode = resolveEffectiveEnvMode({
     activeWorktreePath,
@@ -176,7 +177,7 @@ export default function BranchToolbar({
         activeWorktreePath={activeWorktreePath}
         branchCwd={branchCwd}
         effectiveEnvMode={effectiveEnvMode}
-        envLocked={envLocked}
+        envLocked={envLocked || isMultiRepo}
         onSetThreadBranch={setThreadBranch}
         {...(onCheckoutPullRequestRequest ? { onCheckoutPullRequestRequest } : {})}
         {...(onComposerFocusRequest ? { onComposerFocusRequest } : {})}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1048,8 +1048,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
     [activeProject?.id, activeProject?.remote, activeThread?.id, gitCwd],
   );
   const gitTarget = useMemo(
-    () => ({ cwd: gitCwd, projectId: activeProject?.id ?? null }),
-    [activeProject?.id, gitCwd],
+    () =>
+      activeProject?.gitMode === "multi"
+        ? { cwd: null, projectId: activeProject.id }
+        : { cwd: gitCwd, projectId: activeProject?.id ?? null },
+    [activeProject?.gitMode, activeProject?.id, gitCwd],
   );
   const composerTriggerKind = composerTrigger?.kind ?? null;
   const pathTriggerQuery = composerTrigger?.kind === "path" ? composerTrigger.query : "";
@@ -1210,8 +1213,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
       worktreePath: activeThreadWorktreePath,
     });
   }, [activeProjectCwd, activeThreadWorktreePath]);
-  // Default true while loading to avoid toolbar flicker.
-  const isGitRepo = branchesQuery.data?.isRepo ?? true;
+  const isGitRepo =
+    activeProject?.gitMode === "multi" ? false : (branchesQuery.data?.isRepo ?? true);
   const fallbackComposerThreadId =
     showComposerThreadId && !isGitRepo ? visibleProviderThreadId : null;
   const terminalToggleShortcutLabel = useMemo(
@@ -3605,7 +3608,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
           draftThreadTitleOverride={isLocalDraftThread ? draftThreadTitleOverride : null}
           activeProjectId={activeProject?.id ?? null}
           activeProjectName={activeProject?.name}
+          activeProjectGitMode={activeProject?.gitMode ?? null}
           activeProjectRemote={activeProject?.remote ?? null}
+          disableGitActions={activeProject?.gitMode === "multi"}
           isRemoteProject={Boolean(activeProject?.remote)}
           isGitRepo={isGitRepo}
           openInCwd={gitCwd}

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -59,6 +59,7 @@ interface GitActionsControlProps {
   gitTarget: GitQueryTarget;
   activeThreadId: ThreadId | null;
   projectRemote: ProjectRemoteTarget | null;
+  disableGitActions?: boolean;
 }
 
 interface PendingDefaultBranchAction {
@@ -212,6 +213,7 @@ export default function GitActionsControl({
   gitTarget,
   activeThreadId,
   projectRemote,
+  disableGitActions = false,
 }: GitActionsControlProps) {
   const { settings } = useAppSettings();
   const gitCwd = gitTarget.cwd;
@@ -296,19 +298,32 @@ export default function GitActionsControl({
   }, [branchList?.branches, gitStatusForActions?.branch]);
 
   const gitActionMenuItems = useMemo(
-    () => buildMenuItems(gitStatusForActions, isGitActionRunning, hasOriginRemote),
-    [gitStatusForActions, hasOriginRemote, isGitActionRunning],
+    () =>
+      buildMenuItems(
+        gitStatusForActions,
+        disableGitActions ? true : isGitActionRunning,
+        hasOriginRemote,
+      ),
+    [disableGitActions, gitStatusForActions, hasOriginRemote, isGitActionRunning],
   );
   const quickAction = useMemo(
     () =>
-      resolveQuickAction(
-        gitStatusForActions,
-        isGitActionRunning,
-        isDefaultBranch,
-        hasOriginRemote,
-        settings.gitDefaultAction,
-      ),
+      disableGitActions
+        ? {
+            label: "Commit",
+            disabled: true,
+            kind: "show_hint" as const,
+            hint: "Git actions are disabled for multi-repo projects right now.",
+          }
+        : resolveQuickAction(
+            gitStatusForActions,
+            isGitActionRunning,
+            isDefaultBranch,
+            hasOriginRemote,
+            settings.gitDefaultAction,
+          ),
     [
+      disableGitActions,
       gitStatusForActions,
       hasOriginRemote,
       isDefaultBranch,
@@ -450,6 +465,14 @@ export default function GitActionsControl({
       progressToastId,
       filePaths,
     }: RunGitActionWithToastInput) => {
+      if (disableGitActions) {
+        toastManager.add({
+          type: "error",
+          title: "Git actions are disabled for multi-repo projects right now.",
+          data: threadToastData,
+        });
+        return;
+      }
       const actionStatus = statusOverride ?? gitStatusForActions;
       const actionBranch = actionStatus?.branch ?? null;
       const actionIsDefaultBranch =

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -518,13 +518,19 @@ export default function Sidebar() {
   );
   const threadGitTargets = useMemo(
     () =>
-      threads.map((thread) => ({
-        threadId: thread.id,
-        branch: thread.branch,
-        projectId: thread.projectId,
-        cwd: thread.worktreePath ?? projectCwdById.get(thread.projectId) ?? null,
-      })),
-    [projectCwdById, threads],
+      threads.map((thread) => {
+        const project = projects.find((entry) => entry.id === thread.projectId);
+        return {
+          threadId: thread.id,
+          branch: thread.branch,
+          projectId: thread.projectId,
+          cwd:
+            project?.gitMode === "multi"
+              ? null
+              : (thread.worktreePath ?? projectCwdById.get(thread.projectId) ?? null),
+        };
+      }),
+    [projectCwdById, projects, threads],
   );
   const threadGitStatusTargets = useMemo(
     () => [

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -1,6 +1,7 @@
 import {
   type EditorId,
   type ProjectId,
+  type ProjectGitMode,
   type ProjectRemoteTarget,
   type ProjectScript,
   type ResolvedKeybindingsConfig,
@@ -24,7 +25,9 @@ interface ChatHeaderProps {
   draftThreadTitleOverride: string | null;
   activeProjectId: ProjectId | null;
   activeProjectName: string | undefined;
+  activeProjectGitMode: ProjectGitMode | null;
   activeProjectRemote: ProjectRemoteTarget | null;
+  disableGitActions?: boolean;
   isRemoteProject: boolean;
   isGitRepo: boolean;
   openInCwd: string | null;
@@ -54,7 +57,9 @@ export const ChatHeader = memo(function ChatHeader({
   draftThreadTitleOverride,
   activeProjectId,
   activeProjectName,
+  activeProjectGitMode,
   activeProjectRemote,
+  disableGitActions = false,
   isRemoteProject,
   isGitRepo,
   openInCwd,
@@ -81,6 +86,14 @@ export const ChatHeader = memo(function ChatHeader({
   const draftThreadTitleInputRef = useRef<HTMLInputElement | null>(null);
   const isDraftThreadTitleEditable = onDraftThreadTitleOverrideChange !== null;
   const visibleDraftThreadTitle = draftThreadTitleOverride?.trim() || activeThreadTitle;
+  const gitModeLabel =
+    activeProjectGitMode === null
+      ? null
+      : activeProjectGitMode === "multi"
+        ? "Multiple Git Repos"
+        : activeProjectGitMode === "single"
+          ? "Git Repo"
+          : "No Git";
 
   useEffect(() => {
     setIsEditingDraftThreadTitle(false);
@@ -146,9 +159,13 @@ export const ChatHeader = memo(function ChatHeader({
             {activeProjectName}
           </Badge>
         )}
-        {activeProjectName && !isGitRepo && !isRemoteProject && (
-          <Badge variant="outline" className="shrink-0 text-[10px] text-amber-700">
-            No Git
+        {activeProjectName && gitModeLabel && (
+          <Badge
+            variant="outline"
+            className="shrink-0 text-[10px] text-amber-700 data-[git-mode=single]:text-foreground data-[git-mode=multi]:text-foreground"
+            data-git-mode={activeProjectGitMode}
+          >
+            {gitModeLabel}
           </Badge>
         )}
       </div>
@@ -180,6 +197,7 @@ export const ChatHeader = memo(function ChatHeader({
             gitTarget={gitTarget}
             activeThreadId={activeThreadId}
             projectRemote={activeProjectRemote}
+            disableGitActions={disableGitActions}
           />
         )}
         <Tooltip>
@@ -224,7 +242,9 @@ export const ChatHeader = memo(function ChatHeader({
           />
           <TooltipPopup side="bottom">
             {!isGitRepo
-              ? "Diff panel is unavailable because this project is not a git repository."
+              ? activeProjectGitMode === "multi"
+                ? "Diff panel is unavailable for multi-repo projects right now."
+                : "Diff panel is unavailable because this project is not a git repository."
               : diffToggleShortcutLabel
                 ? `Toggle diff panel (${diffToggleShortcutLabel})`
                 : "Toggle diff panel"}

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -168,6 +168,8 @@ function mapProjectsFromReadModel(
       remote: project.remote ?? null,
       expanded: true,
       scripts: project.scripts.map((script) => ({ ...script })),
+      gitMode: project.gitMode ?? "none",
+      gitRepos: project.gitRepos?.map((repo) => ({ ...repo })) ?? null,
     } satisfies Project;
     const projectKey = projectPersistenceKey(nextProject);
     return {

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -5,6 +5,8 @@ import type {
   OrchestrationProposedPlanId,
   OrchestrationSessionStatus,
   OrchestrationThreadActivity,
+  ProjectGitMode,
+  ProjectGitRepo,
   ProjectRemoteTarget,
   ProjectScript as ContractProjectScript,
   ThreadId,
@@ -89,6 +91,8 @@ export interface Project {
   createdAt?: string | undefined;
   updatedAt?: string | undefined;
   scripts: ProjectScript[];
+  gitMode?: ProjectGitMode | undefined;
+  gitRepos?: ProjectGitRepo[] | null | undefined;
 }
 
 export interface Thread {

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -148,6 +148,15 @@ export const ProjectScript = Schema.Struct({
 });
 export type ProjectScript = typeof ProjectScript.Type;
 
+export const ProjectGitMode = Schema.Literals(["none", "single", "multi"]);
+export type ProjectGitMode = typeof ProjectGitMode.Type;
+
+export const ProjectGitRepo = Schema.Struct({
+  repoPath: TrimmedNonEmptyString,
+  displayName: TrimmedNonEmptyString,
+});
+export type ProjectGitRepo = typeof ProjectGitRepo.Type;
+
 export const OrchestrationProject = Schema.Struct({
   id: ProjectId,
   title: TrimmedNonEmptyString,
@@ -155,6 +164,8 @@ export const OrchestrationProject = Schema.Struct({
   remote: Schema.optional(Schema.NullOr(ProjectRemoteTarget)),
   defaultModelSelection: Schema.NullOr(ModelSelection),
   scripts: Schema.Array(ProjectScript),
+  gitMode: Schema.optional(ProjectGitMode),
+  gitRepos: Schema.optional(Schema.NullOr(Schema.Array(ProjectGitRepo))),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
   deletedAt: Schema.NullOr(IsoDateTime),
@@ -344,6 +355,8 @@ const ProjectMetaUpdateCommand = Schema.Struct({
   remote: Schema.optional(Schema.NullOr(ProjectRemoteTarget)),
   defaultModelSelection: Schema.optional(Schema.NullOr(ModelSelection)),
   scripts: Schema.optional(Schema.Array(ProjectScript)),
+  gitMode: Schema.optional(ProjectGitMode),
+  gitRepos: Schema.optional(Schema.NullOr(Schema.Array(ProjectGitRepo))),
 });
 
 const ProjectDeleteCommand = Schema.Struct({
@@ -651,6 +664,8 @@ export const ProjectCreatedPayload = Schema.Struct({
   remote: Schema.optional(Schema.NullOr(ProjectRemoteTarget)),
   defaultModelSelection: Schema.NullOr(ModelSelection),
   scripts: Schema.Array(ProjectScript),
+  gitMode: Schema.optional(ProjectGitMode),
+  gitRepos: Schema.optional(Schema.NullOr(Schema.Array(ProjectGitRepo))),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
 });
@@ -662,6 +677,8 @@ export const ProjectMetaUpdatedPayload = Schema.Struct({
   remote: Schema.optional(Schema.NullOr(ProjectRemoteTarget)),
   defaultModelSelection: Schema.optional(Schema.NullOr(ModelSelection)),
   scripts: Schema.optional(Schema.Array(ProjectScript)),
+  gitMode: Schema.optional(ProjectGitMode),
+  gitRepos: Schema.optional(Schema.NullOr(Schema.Array(ProjectGitRepo))),
   updatedAt: IsoDateTime,
 });
 


### PR DESCRIPTION
## What Changed

Basically CR 1 in #53. First CR is the following:
1) Extended Project Schema to include to new fields: gitMode and gitRepo. gitMode is "none", "single", "multi" and gitRepos is relative to the project direct
2) Enable auto-discovery of gitMode on thread launch
3) Disable all gitaction for mult-repo use for right now 

## Why
Breaking in the CRs was needed to prevent project scope

## Validation

1) Check to make sure non-git repos, single git repos and multi got repos are discovered properly
2) Check to make sure turn diff, git actions etc are all work on single repo
3) Make sure multi-git repos are disable

## Maintenance Impact

## UI Changes
1) Top bar now always disables git mode previous it only did for no git

## Checklist
