### PR TITLE
Guard remote checkpoint diffs and validate workspace git state

### DIFF
--- a/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.test.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.test.ts
@@ -304,4 +304,173 @@ describe("CheckpointDiffQueryLive", () => {
 
     expect(result.diff).toContain("console.log('remote');");
   });
+
+  it("rejects whole-thread diff requests for provider-only checkpoints", async () => {
+    const projectId = ProjectId.makeUnsafe("project-remote");
+    const threadId = ThreadId.makeUnsafe("thread-remote");
+
+    const snapshot: OrchestrationReadModel = {
+      snapshotSequence: 0,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      projects: [
+        {
+          id: projectId,
+          title: "Project",
+          workspaceRoot: "/home/remote-user/project",
+          defaultModel: null,
+          scripts: [],
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+          deletedAt: null,
+        },
+      ],
+      threads: [
+        {
+          id: threadId,
+          projectId,
+          title: "Thread",
+          model: "gpt-5-codex",
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "full-access",
+          branch: null,
+          worktreePath: null,
+          latestTurn: {
+            turnId: TurnId.makeUnsafe("turn-2"),
+            state: "completed",
+            requestedAt: "2026-01-01T00:00:00.000Z",
+            startedAt: "2026-01-01T00:00:00.000Z",
+            completedAt: "2026-01-01T00:00:00.000Z",
+            assistantMessageId: null,
+          },
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+          deletedAt: null,
+          messages: [],
+          activities: [],
+          proposedPlans: [],
+          checkpoints: [
+            {
+              turnId: TurnId.makeUnsafe("turn-1"),
+              checkpointTurnCount: 1,
+              checkpointRef: CheckpointRef.makeUnsafe("provider-diff:evt-remote-1"),
+              status: "missing",
+              files: [],
+              assistantMessageId: null,
+              completedAt: "2026-01-01T00:00:00.000Z",
+            },
+            {
+              turnId: TurnId.makeUnsafe("turn-2"),
+              checkpointTurnCount: 2,
+              checkpointRef: CheckpointRef.makeUnsafe("provider-diff:evt-remote-2"),
+              status: "missing",
+              files: [],
+              assistantMessageId: null,
+              completedAt: "2026-01-01T00:00:00.000Z",
+            },
+          ],
+          session: null,
+        },
+      ],
+    };
+
+    const checkpointStore: CheckpointStoreShape = {
+      isGitRepository: () => Effect.die("checkpoint store should not be used"),
+      captureCheckpoint: () => Effect.void,
+      hasCheckpointRef: () => Effect.die("checkpoint store should not be used"),
+      restoreCheckpoint: () => Effect.succeed(true),
+      diffCheckpoints: () => Effect.die("checkpoint store should not be used"),
+      deleteCheckpointRefs: () => Effect.void,
+    };
+
+    const projectionTurnRepository = {
+      upsertByTurnId: () => Effect.void,
+      replacePendingTurnStart: () => Effect.void,
+      getPendingTurnStartByThreadId: () => Effect.succeed(Option.none()),
+      deletePendingTurnStartByThreadId: () => Effect.void,
+      listByThreadId: () => Effect.succeed([]),
+      getByTurnId: () => Effect.succeed(Option.none()),
+      clearCheckpointTurnConflict: () => Effect.void,
+      deleteByThreadId: () => Effect.void,
+    };
+
+    const layer = CheckpointDiffQueryLive.pipe(
+      Layer.provideMerge(Layer.succeed(CheckpointStore, checkpointStore)),
+      Layer.provideMerge(Layer.succeed(ProjectionTurnRepository, projectionTurnRepository)),
+      Layer.provideMerge(
+        Layer.succeed(ProjectionSnapshotQuery, {
+          getSnapshot: () => Effect.succeed(snapshot),
+        }),
+      ),
+    );
+
+    await expect(
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const query = yield* CheckpointDiffQuery;
+          return yield* query.getFullThreadDiff({
+            threadId,
+            toTurnCount: 2,
+          });
+        }).pipe(Effect.provide(layer)),
+      ),
+    ).rejects.toThrow("Only the per-turn diff for turn 2 is available");
+  });
+
+  it("returns a checkpoint error when the workspace path is unavailable", async () => {
+    const projectId = ProjectId.makeUnsafe("project-missing");
+    const threadId = ThreadId.makeUnsafe("thread-missing-workspace");
+    const toCheckpointRef = checkpointRefForThreadTurn(threadId, 1);
+
+    const snapshot = makeSnapshot({
+      projectId,
+      threadId,
+      workspaceRoot: "/missing/workspace",
+      worktreePath: null,
+      checkpointTurnCount: 1,
+      checkpointRef: toCheckpointRef,
+    });
+
+    const checkpointStore: CheckpointStoreShape = {
+      isGitRepository: () => Effect.succeed(false),
+      captureCheckpoint: () => Effect.void,
+      hasCheckpointRef: () => Effect.die("checkpoint refs should not be resolved"),
+      restoreCheckpoint: () => Effect.succeed(true),
+      diffCheckpoints: () => Effect.die("checkpoint diffs should not be resolved"),
+      deleteCheckpointRefs: () => Effect.void,
+    };
+
+    const projectionTurnRepository = {
+      upsertByTurnId: () => Effect.void,
+      replacePendingTurnStart: () => Effect.void,
+      getPendingTurnStartByThreadId: () => Effect.succeed(Option.none()),
+      deletePendingTurnStartByThreadId: () => Effect.void,
+      listByThreadId: () => Effect.succeed([]),
+      getByTurnId: () => Effect.succeed(Option.none()),
+      clearCheckpointTurnConflict: () => Effect.void,
+      deleteByThreadId: () => Effect.void,
+    };
+
+    const layer = CheckpointDiffQueryLive.pipe(
+      Layer.provideMerge(Layer.succeed(CheckpointStore, checkpointStore)),
+      Layer.provideMerge(Layer.succeed(ProjectionTurnRepository, projectionTurnRepository)),
+      Layer.provideMerge(
+        Layer.succeed(ProjectionSnapshotQuery, {
+          getSnapshot: () => Effect.succeed(snapshot),
+        }),
+      ),
+    );
+
+    await expect(
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const query = yield* CheckpointDiffQuery;
+          return yield* query.getTurnDiff({
+            threadId,
+            fromTurnCount: 0,
+            toTurnCount: 1,
+          });
+        }).pipe(Effect.provide(layer)),
+      ),
+    ).rejects.toThrow("workspace '/missing/workspace' is missing or is not a git repository");
+  });
 });

--- a/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.ts
@@ -103,6 +103,17 @@ const make = Effect.gen(function* () {
         });
       }
 
+      if (toCheckpoint && isProviderDiffCheckpointRef(toCheckpoint.checkpointRef)) {
+        const supportedFromTurnCount = Math.max(0, input.toTurnCount - 1);
+        if (input.fromTurnCount !== supportedFromTurnCount) {
+          return yield* new CheckpointUnavailableError({
+            threadId: input.threadId,
+            turnCount: input.toTurnCount,
+            detail: `Only the per-turn diff for turn ${input.toTurnCount} is available for this checkpoint source. Select that turn instead of viewing all turns.`,
+          });
+        }
+      }
+
       if (
         toCheckpoint &&
         isProviderDiffCheckpointRef(toCheckpoint.checkpointRef) &&
@@ -135,6 +146,15 @@ const make = Effect.gen(function* () {
           threadId: input.threadId,
           turnCount: input.toTurnCount,
           detail: `Provider diff is unavailable for turn ${input.toTurnCount}.`,
+        });
+      }
+
+      const isGitRepository = yield* checkpointStore.isGitRepository(workspaceCwd);
+      if (!isGitRepository) {
+        return yield* new CheckpointUnavailableError({
+          threadId: input.threadId,
+          turnCount: input.toTurnCount,
+          detail: `Turn diffs are unavailable because workspace '${workspaceCwd}' is missing or is not a git repository.`,
         });
       }
 


### PR DESCRIPTION
- Reject full-thread diff requests for provider-only checkpoints with a clear per-turn guidance error
- Fail turn diff requests early when the workspace path is missing or not a git repository
- Add regression tests for provider-only diff restrictions and missing workspace handling

## What Changed

## Why

## Validation

## Maintenance Impact

## UI Changes

## Checklist


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for checkpoint operations to prevent unsupported requests and provide clearer error messages when workspaces are missing or misconfigured.

* **Tests**
  * Added integration tests for checkpoint query validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->