### PR TITLE
feat: surface Kiro tool approvals

### DIFF
--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -41,6 +41,8 @@ import { ProviderSessionDirectoryLive } from "../src/provider/Layers/ProviderSes
 import { makeProviderServiceLive } from "../src/provider/Layers/ProviderService.ts";
 import { makeCodexAdapterLive } from "../src/provider/Layers/CodexAdapter.ts";
 import { CodexAdapter } from "../src/provider/Services/CodexAdapter.ts";
+import { makeKiroAdapterLive } from "../src/provider/Layers/KiroAdapter.ts";
+import { KiroAdapter } from "../src/provider/Services/KiroAdapter.ts";
 import { ProviderService } from "../src/provider/Services/ProviderService.ts";
 import { AnalyticsService } from "../src/telemetry/Services/AnalyticsService.ts";
 import { CheckpointReactorLive } from "../src/orchestration/Layers/CheckpointReactor.ts";
@@ -210,7 +212,7 @@ export interface OrchestrationIntegrationHarness {
 
 interface MakeOrchestrationIntegrationHarnessOptions {
   readonly provider?: ProviderKind;
-  readonly realCodex?: boolean;
+  readonly realProvider?: ProviderKind;
 }
 
 export const makeOrchestrationIntegrationHarness = (
@@ -221,8 +223,10 @@ export const makeOrchestrationIntegrationHarness = (
     const fileSystem = yield* FileSystem.FileSystem;
 
     const provider = options?.provider ?? "codex";
-    const useRealCodex = options?.realCodex === true;
-    const adapterHarness = useRealCodex
+    const realProvider = options?.realProvider;
+    const effectiveProvider = realProvider ?? provider;
+    const useRealProvider = realProvider !== undefined;
+    const adapterHarness = useRealProvider
       ? null
       : yield* makeTestProviderAdapterHarness({
           provider,
@@ -256,28 +260,48 @@ export const makeOrchestrationIntegrationHarness = (
     const providerSessionDirectoryLayer = ProviderSessionDirectoryLive.pipe(
       Layer.provide(ProviderSessionRuntimeRepositoryLive),
     );
-    const realCodexRegistry = Layer.effect(
+    const realProviderRegistry = Layer.effect(
       ProviderAdapterRegistry,
       Effect.gen(function* () {
-        const codexAdapter = yield* CodexAdapter;
+        if (effectiveProvider === "codex") {
+          const codexAdapter = yield* CodexAdapter;
+          return {
+            getByProvider: (resolvedProvider) =>
+              resolvedProvider === "codex"
+                ? Effect.succeed(codexAdapter)
+                : Effect.fail(new ProviderUnsupportedError({ provider: resolvedProvider })),
+            listProviders: () => Effect.succeed(["codex"] as const),
+          } as typeof ProviderAdapterRegistry.Service;
+        }
+
+        if (effectiveProvider === "kiro") {
+          const kiroAdapter = yield* KiroAdapter;
+          return {
+            getByProvider: (resolvedProvider) =>
+              resolvedProvider === "kiro"
+                ? Effect.succeed(kiroAdapter)
+                : Effect.fail(new ProviderUnsupportedError({ provider: resolvedProvider })),
+            listProviders: () => Effect.succeed(["kiro"] as const),
+          } as typeof ProviderAdapterRegistry.Service;
+        }
+
         return {
           getByProvider: (resolvedProvider) =>
-            resolvedProvider === "codex"
-              ? Effect.succeed(codexAdapter)
-              : Effect.fail(new ProviderUnsupportedError({ provider: resolvedProvider })),
-          listProviders: () => Effect.succeed(["codex"] as const),
+            Effect.fail(new ProviderUnsupportedError({ provider: resolvedProvider })),
+          listProviders: () => Effect.succeed([] as const),
         } as typeof ProviderAdapterRegistry.Service;
       }),
     ).pipe(
       Layer.provide(makeCodexAdapterLive()),
+      Layer.provide(makeKiroAdapterLive()),
       Layer.provideMerge(ServerConfig.layerTest(workspaceDir, rootDir)),
       Layer.provideMerge(NodeServices.layer),
       Layer.provideMerge(providerSessionDirectoryLayer),
     );
-    const providerLayer = useRealCodex
+    const providerLayer = useRealProvider
       ? makeProviderServiceLive().pipe(
           Layer.provide(providerSessionDirectoryLayer),
-          Layer.provide(realCodexRegistry),
+          Layer.provide(realProviderRegistry),
           Layer.provide(AnalyticsService.layerTest),
         )
       : makeProviderServiceLive().pipe(

--- a/apps/server/integration/kiroApprovalSurfacing.integration.test.ts
+++ b/apps/server/integration/kiroApprovalSurfacing.integration.test.ts
@@ -1,0 +1,383 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  ApprovalRequestId,
+  CommandId,
+  DEFAULT_MODEL_BY_PROVIDER,
+  DEFAULT_PROVIDER_INTERACTION_MODE,
+  MessageId,
+  ProjectId,
+  ThreadId,
+  type ProviderStartOptions,
+} from "@t3tools/contracts";
+import { assert, it } from "@effect/vitest";
+import { Effect } from "effect";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+
+import {
+  makeOrchestrationIntegrationHarness,
+  type OrchestrationIntegrationHarness,
+} from "./OrchestrationEngineHarness.integration.ts";
+
+const PROJECT_ID = ProjectId.makeUnsafe("project-kiro-approval-probe");
+const THREAD_ID = ThreadId.makeUnsafe("thread-kiro-approval-probe");
+const KIRO_PROVIDER = "kiro" as const;
+const RUN_LIVE_KIRO_APPROVAL_TESTS = process.env.RUN_LIVE_KIRO_APPROVAL_TESTS === "1";
+const KIRO_BINARY_PATH = process.env.KIRO_BINARY_PATH ?? "kiro-cli";
+
+type ApprovalProbe = {
+  readonly label: string;
+  readonly agentTool: string;
+  readonly expectApproval: boolean;
+  readonly goal: string;
+};
+
+const TOOL_APPROVAL_PROBES: ReadonlyArray<ApprovalProbe> = [
+  {
+    label: "code",
+    agentTool: "code",
+    expectApproval: false,
+    goal: "Use the code tool to inspect this workspace for the symbol or text 'README'.",
+  },
+  {
+    label: "glob",
+    agentTool: "glob",
+    expectApproval: false,
+    goal: "Use glob to list a few files matching **/*.test.ts in this workspace.",
+  },
+  {
+    label: "grep",
+    agentTool: "grep",
+    expectApproval: false,
+    goal: "Use grep to search this workspace for the pattern approval.requested.",
+  },
+  {
+    label: "introspect",
+    agentTool: "introspect",
+    expectApproval: false,
+    goal: "Use introspect to answer how Kiro CLI saves conversations.",
+  },
+  {
+    label: "knowledge",
+    agentTool: "knowledge",
+    expectApproval: true,
+    goal: "Use the knowledge tool to create or query a tiny temporary knowledge base entry named approval-probe.",
+  },
+  {
+    label: "read",
+    agentTool: "read",
+    expectApproval: false,
+    goal: "Use read to inspect README.md and report the first line.",
+  },
+  {
+    label: "shell",
+    agentTool: "shell",
+    expectApproval: true,
+    goal: "Use shell to run the smallest safe read-only command possible, such as pwd.",
+  },
+  {
+    label: "subagent",
+    agentTool: "subagent",
+    expectApproval: true,
+    goal: "Use subagent to delegate one tiny workspace-inspection task.",
+  },
+  {
+    label: "todo_list",
+    agentTool: "todo",
+    expectApproval: true,
+    goal: "Use the todo tool to create a single todo item named approval probe.",
+  },
+  {
+    label: "use_aws",
+    agentTool: "aws",
+    expectApproval: true,
+    goal: "Use aws to run a minimal read-only AWS CLI operation such as sts get-caller-identity.",
+  },
+  {
+    label: "web_fetch",
+    agentTool: "web_fetch",
+    expectApproval: true,
+    goal: "Use web_fetch to retrieve https://example.com and summarize the title.",
+  },
+  {
+    label: "web_search",
+    agentTool: "web_search",
+    expectApproval: true,
+    goal: "Use web_search to search for Kiro CLI ACP.",
+  },
+  {
+    label: "write",
+    agentTool: "write",
+    expectApproval: true,
+    goal: "Use write to create a file named .kiro-approval-probe.txt with the text probe.",
+  },
+] as const;
+
+function withRealKiroHarness<A, E>(
+  use: (harness: OrchestrationIntegrationHarness) => Effect.Effect<A, E>,
+) {
+  return Effect.acquireUseRelease(
+    makeOrchestrationIntegrationHarness({ provider: KIRO_PROVIDER, realProvider: KIRO_PROVIDER }),
+    use,
+    (harness) => harness.dispose,
+  ).pipe(Effect.provide(NodeServices.layer));
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function shQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function sanitizeProbeLabel(value: string): string {
+  return value.toLowerCase().replaceAll(/[^a-z0-9]+/g, "-");
+}
+
+function buildProbeAgentConfig(probe: ApprovalProbe) {
+  return {
+    // Override Kiro's default interaction mode for this isolated workspace so
+    // the production session/set_mode flow stays on the one-tool probe agent.
+    name: "kiro_default",
+    description: `ACP approval surfacing probe for ${probe.label}`,
+    includeMcpJson: true,
+    tools: [probe.agentTool],
+    ...(probe.expectApproval ? {} : { allowedTools: [probe.agentTool] }),
+    prompt: [
+      `You are a deterministic ACP approval probe for the ${probe.label} tool.`,
+      "You have exactly one tool available through your agent configuration.",
+      "When the user asks you to run the probe, you must invoke that tool immediately.",
+      "Do not answer from memory and do not say the tool is unavailable unless the runtime truly refuses it.",
+      probe.goal,
+      "If the tool requires approval, request it and wait.",
+    ].join(" "),
+  };
+}
+
+function writeProbeAgentFiles(
+  workspaceDir: string,
+  probe: ApprovalProbe,
+): {
+  readonly wrapperPath: string;
+} {
+  const agentDir = path.join(workspaceDir, ".kiro", "agents");
+  fs.mkdirSync(agentDir, { recursive: true });
+
+  const agentConfig = buildProbeAgentConfig(probe);
+  const agentFileName = `${agentConfig.name}.json`;
+  fs.writeFileSync(path.join(agentDir, agentFileName), JSON.stringify(agentConfig, null, 2));
+
+  const wrapperPath = path.join(agentDir, `${agentConfig.name}-launcher.sh`);
+  fs.writeFileSync(
+    wrapperPath,
+    [
+      "#!/bin/sh",
+      `exec ${shQuote(KIRO_BINARY_PATH)} "$@" --agent ${shQuote(agentConfig.name)}`,
+      "",
+    ].join("\n"),
+  );
+  fs.chmodSync(wrapperPath, 0o755);
+
+  return { wrapperPath };
+}
+
+const seedProjectAndThread = (harness: OrchestrationIntegrationHarness) =>
+  Effect.gen(function* () {
+    const createdAt = nowIso();
+    yield* harness.engine.dispatch({
+      type: "project.create",
+      commandId: CommandId.makeUnsafe("cmd-kiro-project-create"),
+      projectId: PROJECT_ID,
+      title: "Kiro Approval Probe Project",
+      workspaceRoot: harness.workspaceDir,
+      defaultModelSelection: {
+        provider: KIRO_PROVIDER,
+        model: DEFAULT_MODEL_BY_PROVIDER[KIRO_PROVIDER],
+      },
+      createdAt,
+    });
+
+    yield* harness.engine.dispatch({
+      type: "thread.create",
+      commandId: CommandId.makeUnsafe("cmd-kiro-thread-create"),
+      threadId: THREAD_ID,
+      projectId: PROJECT_ID,
+      title: "Kiro Approval Probe Thread",
+      modelSelection: {
+        provider: KIRO_PROVIDER,
+        model: DEFAULT_MODEL_BY_PROVIDER[KIRO_PROVIDER],
+      },
+      interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+      runtimeMode: "approval-required",
+      projectPath: harness.workspaceDir,
+      branch: [null],
+      worktreePath: [null],
+      createdAt,
+    });
+  });
+
+const startProbeTurn = (input: {
+  readonly harness: OrchestrationIntegrationHarness;
+  readonly probe: ApprovalProbe;
+  readonly providerOptions: ProviderStartOptions;
+}) =>
+  input.harness.engine.dispatch({
+    type: "thread.turn.start",
+    commandId: CommandId.makeUnsafe(`cmd-turn-start-${sanitizeProbeLabel(input.probe.label)}`),
+    threadId: THREAD_ID,
+    message: {
+      messageId: MessageId.makeUnsafe(`msg-${sanitizeProbeLabel(input.probe.label)}`),
+      role: "user",
+      text: "Run the approval surfacing probe now.",
+      attachments: [],
+    },
+    providerOptions: input.providerOptions,
+    interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+    runtimeMode: "approval-required",
+    createdAt: nowIso(),
+  });
+
+const waitForActiveTurnId = (harness: OrchestrationIntegrationHarness) =>
+  harness
+    .waitForThread(
+      THREAD_ID,
+      (thread) => thread.latestTurn !== null && thread.latestTurn.startedAt !== null,
+      30_000,
+    )
+    .pipe(
+      Effect.map((thread) => {
+        const turnId = thread.latestTurn?.turnId;
+        if (!turnId) {
+          throw new Error("Expected projected thread to have an active turn.");
+        }
+        return turnId;
+      }),
+    );
+
+const runProbeAndAssert = (probe: ApprovalProbe) =>
+  withRealKiroHarness((harness) =>
+    Effect.gen(function* () {
+      yield* seedProjectAndThread(harness);
+      const { wrapperPath } = writeProbeAgentFiles(harness.workspaceDir, probe);
+
+      yield* startProbeTurn({
+        harness,
+        probe,
+        providerOptions: {
+          kiro: {
+            binaryPath: wrapperPath,
+          },
+        },
+      });
+
+      const turnId = yield* waitForActiveTurnId(harness);
+
+      if (probe.expectApproval) {
+        const threadAfterApprovalWindow = yield* harness.waitForThread(
+          THREAD_ID,
+          (thread) =>
+            thread.latestTurn?.turnId === turnId &&
+            (thread.activities.some(
+              (activity) => activity.turnId === turnId && activity.kind === "approval.requested",
+            ) ||
+              thread.latestTurn.completedAt !== null),
+          30_000,
+        );
+        const approvalActivity = threadAfterApprovalWindow.activities.find(
+          (activity) => activity.turnId === turnId && activity.kind === "approval.requested",
+        );
+        if (approvalActivity === undefined) {
+          throw new Error(
+            `Expected an approval request for ${probe.label}, but the turn completed without surfacing one.`,
+          );
+        }
+
+        const payload =
+          approvalActivity?.payload && typeof approvalActivity.payload === "object"
+            ? (approvalActivity.payload as Record<string, unknown>)
+            : null;
+        const requestId =
+          payload && typeof payload.requestId === "string"
+            ? ApprovalRequestId.makeUnsafe(payload.requestId)
+            : null;
+        assert.ok(requestId !== null);
+
+        yield* harness.waitForPendingApproval(
+          String(requestId),
+          (row) => row.status === "pending",
+          30_000,
+        );
+
+        yield* harness.engine.dispatch({
+          type: "thread.approval.respond",
+          commandId: CommandId.makeUnsafe(`cmd-approval-cancel-${sanitizeProbeLabel(probe.label)}`),
+          threadId: THREAD_ID,
+          requestId: requestId!,
+          decision: "cancel",
+          createdAt: nowIso(),
+        });
+
+        yield* harness.waitForPendingApproval(
+          String(requestId),
+          (row) => row.status === "resolved" && row.decision === "cancel",
+          30_000,
+        );
+        return;
+      }
+
+      const threadWithToolActivity = yield* harness.waitForThread(
+        THREAD_ID,
+        (thread) =>
+          thread.latestTurn?.turnId === turnId &&
+          (thread.activities.some(
+            (activity) => activity.turnId === turnId && activity.kind === "approval.requested",
+          ) ||
+            thread.activities.some(
+              (activity) =>
+                activity.turnId === turnId &&
+                (activity.kind === "tool.started" || activity.kind === "tool.completed"),
+            ) ||
+            thread.latestTurn.completedAt !== null),
+        30_000,
+      );
+
+      if (
+        threadWithToolActivity.activities.some(
+          (activity) => activity.turnId === turnId && activity.kind === "approval.requested",
+        )
+      ) {
+        throw new Error(
+          `Expected ${probe.label} to run without approval, but an approval request was surfaced.`,
+        );
+      }
+
+      if (
+        !threadWithToolActivity.activities.some(
+          (activity) =>
+            activity.turnId === turnId &&
+            (activity.kind === "tool.started" || activity.kind === "tool.completed"),
+        )
+      ) {
+        throw new Error(`Expected ${probe.label} to produce tool activity, but none was observed.`);
+      }
+
+      yield* harness.waitForThread(
+        THREAD_ID,
+        (thread) =>
+          thread.latestTurn?.turnId === turnId &&
+          thread.latestTurn.completedAt !== null &&
+          thread.session?.status === "ready",
+        30_000,
+      );
+    }),
+  );
+
+for (const probe of TOOL_APPROVAL_PROBES) {
+  it.live.skipIf(!RUN_LIVE_KIRO_APPROVAL_TESTS)(
+    `surfaces Kiro ACP approval state correctly for ${probe.label}`,
+    () => runProbeAndAssert(probe),
+    180_000,
+  );
+}

--- a/apps/server/integration/orchestrationEngine.integration.test.ts
+++ b/apps/server/integration/orchestrationEngine.integration.test.ts
@@ -98,7 +98,7 @@ function withRealCodexHarness<A, E>(
   use: (harness: OrchestrationIntegrationHarness) => Effect.Effect<A, E>,
 ) {
   return Effect.acquireUseRelease(
-    makeOrchestrationIntegrationHarness({ provider: "codex", realCodex: true }),
+    makeOrchestrationIntegrationHarness({ provider: "codex", realProvider: "codex" }),
     use,
     (harness) => harness.dispose,
   ).pipe(Effect.provide(NodeServices.layer));

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -1856,6 +1856,45 @@ describe("ProviderRuntimeIngestion", () => {
     expect(resolvedPayload?.requestType).toBe("command_execution_approval");
   });
 
+  it("keeps generic tool approvals actionable", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "request.opened",
+      eventId: asEventId("evt-request-opened-tool"),
+      provider: "kiro",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      requestId: ApprovalRequestId.makeUnsafe("req-tool"),
+      payload: {
+        requestType: "unknown",
+        detail: "Querying knowledge base",
+      },
+    });
+
+    await waitForThread(harness.engine, (entry) =>
+      entry.activities.some(
+        (activity: ProviderRuntimeTestActivity) => activity.id === "evt-request-opened-tool",
+      ),
+    );
+
+    const readModel = await Effect.runPromise(harness.engine.getReadModel());
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"));
+    expect(thread).toBeDefined();
+
+    const requested = thread?.activities.find(
+      (activity: ProviderRuntimeTestActivity) => activity.id === "evt-request-opened-tool",
+    );
+    const requestedPayload =
+      requested?.payload && typeof requested.payload === "object"
+        ? (requested.payload as Record<string, unknown>)
+        : undefined;
+    expect(requested?.summary).toBe("Tool approval requested");
+    expect(requestedPayload?.requestKind).toBe("tool");
+    expect(requestedPayload?.requestType).toBe("unknown");
+  });
+
   it("maps runtime.error into errored session state", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -187,7 +187,7 @@ function orchestrationSessionStatusFromRuntimeState(
 
 function requestKindFromCanonicalRequestType(
   requestType: string | undefined,
-): "command" | "file-read" | "file-change" | undefined {
+): "command" | "file-read" | "file-change" | "tool" | undefined {
   switch (requestType) {
     case "command_execution_approval":
     case "exec_command_approval":
@@ -197,6 +197,9 @@ function requestKindFromCanonicalRequestType(
     case "file_change_approval":
     case "apply_patch_approval":
       return "file-change";
+    case "dynamic_tool_call":
+    case "unknown":
+      return "tool";
     default:
       return undefined;
   }
@@ -258,7 +261,9 @@ function runtimeEventToActivities(
                 ? "File-read approval requested"
                 : requestKind === "file-change"
                   ? "File-change approval requested"
-                  : "Approval requested",
+                  : requestKind === "tool"
+                    ? "Tool approval requested"
+                    : "Approval requested",
           payload: {
             requestId: toApprovalRequestId(event.requestId),
             ...(requestKind ? { requestKind } : {}),

--- a/apps/web/src/components/chat/ComposerPendingApprovalPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingApprovalPanel.tsx
@@ -15,7 +15,9 @@ export const ComposerPendingApprovalPanel = memo(function ComposerPendingApprova
       ? "Command approval requested"
       : approval.requestKind === "file-read"
         ? "File-read approval requested"
-        : "File-change approval requested";
+        : approval.requestKind === "file-change"
+          ? "File-change approval requested"
+          : "Tool approval requested";
 
   return (
     <div className="px-4 py-3.5 sm:px-5 sm:py-4">

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -833,6 +833,7 @@ function workEntryIcon(workEntry: TimelineWorkEntry): LucideIcon {
   if (workEntry.requestKind === "command") return TerminalIcon;
   if (workEntry.requestKind === "file-read") return EyeIcon;
   if (workEntry.requestKind === "file-change") return SquarePenIcon;
+  if (workEntry.requestKind === "tool") return WrenchIcon;
 
   if (workEntry.itemType === "command_execution" || workEntry.command) {
     return TerminalIcon;

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -113,6 +113,32 @@ describe("derivePendingApprovals", () => {
     ]);
   });
 
+  it("keeps generic tool approvals actionable", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "approval-open-tool",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "approval.requested",
+        summary: "Tool approval requested",
+        tone: "approval",
+        payload: {
+          requestId: "req-tool",
+          requestType: "unknown",
+          detail: "Querying knowledge base",
+        },
+      }),
+    ];
+
+    expect(derivePendingApprovals(activities)).toEqual([
+      {
+        requestId: "req-tool",
+        requestKind: "tool",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        detail: "Querying knowledge base",
+      },
+    ]);
+  });
+
   it("clears stale pending approvals when provider reports unknown pending request", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -47,7 +47,7 @@ export interface WorkLogEntry {
 
 export interface PendingApproval {
   requestId: ApprovalRequestId;
-  requestKind: "command" | "file-read" | "file-change";
+  requestKind: "command" | "file-read" | "file-change" | "tool";
   createdAt: string;
   detail?: string;
 }
@@ -155,6 +155,9 @@ function requestKindFromRequestType(requestType: unknown): PendingApproval["requ
     case "file_change_approval":
     case "apply_patch_approval":
       return "file-change";
+    case "dynamic_tool_call":
+    case "unknown":
+      return "tool";
     default:
       return null;
   }
@@ -179,7 +182,8 @@ export function derivePendingApprovals(
       payload &&
       (payload.requestKind === "command" ||
         payload.requestKind === "file-read" ||
-        payload.requestKind === "file-change")
+        payload.requestKind === "file-change" ||
+        payload.requestKind === "tool")
         ? payload.requestKind
         : payload
           ? requestKindFromRequestType(payload.requestType)
@@ -549,7 +553,8 @@ function extractWorkLogRequestKind(
   if (
     payload?.requestKind === "command" ||
     payload?.requestKind === "file-read" ||
-    payload?.requestKind === "file-change"
+    payload?.requestKind === "file-change" ||
+    payload?.requestKind === "tool"
   ) {
     return payload.requestKind;
   }


### PR DESCRIPTION
- Treat generic Kiro tool requests as actionable approvals
- Update server and web UI to label tool approvals consistently
- Add live Kiro approval surfacing coverage

## What Changed

## Why

## Validation

## Maintenance Impact

## UI Changes

## Checklist


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System now recognizes generic "tool" approval requests so tool-execution approvals are tracked and surfaced.

* **UI**
  * Composer and timeline now show "Tool approval requested" messaging and a consistent tool icon for these approvals.

* **Tests**
  * Added unit and live integration tests validating tool-approval ingestion, pending-approval derivation, and end-to-end Kiro approval flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->