### PR TITLE
Handle Kiro resume fallback and show reconnect toast

### DIFF
--- a/apps/server/src/kiroAcpManager.test.ts
+++ b/apps/server/src/kiroAcpManager.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import { ThreadId, TurnId } from "@t3tools/contracts";
 
@@ -146,6 +147,109 @@ Current context window (5.9% used)
 });
 
 describe("KiroAcpManager", () => {
+  it("falls back to a fresh session when session/load returns a recoverable internal error", async () => {
+    class FakeStream extends EventEmitter {
+      setEncoding(): this {
+        return this;
+      }
+    }
+
+    class FakeProcess extends EventEmitter {
+      readonly stdout = new FakeStream();
+      readonly stderr = new FakeStream();
+      readonly stdin = {
+        write: vi.fn((line: string) => {
+          const message = JSON.parse(line) as {
+            id: number;
+            method: string;
+          };
+          if (message.method === "initialize") {
+            this.stdout.emit(
+              "data",
+              `${JSON.stringify({ jsonrpc: "2.0", id: message.id, result: {} })}\n`,
+            );
+            return true;
+          }
+          if (message.method === "session/load") {
+            this.stdout.emit(
+              "data",
+              `${JSON.stringify({
+                jsonrpc: "2.0",
+                id: message.id,
+                error: { code: -32603, message: "Internal error" },
+              })}\n`,
+            );
+            return true;
+          }
+          if (message.method === "session/new") {
+            this.stdout.emit(
+              "data",
+              `${JSON.stringify({
+                jsonrpc: "2.0",
+                id: message.id,
+                result: { sessionId: "session-fresh" },
+              })}\n`,
+            );
+            return true;
+          }
+          throw new Error(`Unexpected RPC method in test: ${message.method}`);
+        }),
+      };
+      kill = vi.fn();
+    }
+
+    const manager = new KiroAcpManager();
+    const fakeProcess = new FakeProcess();
+    (
+      manager as unknown as {
+        spawnProcess: () => { process: FakeProcess; command: string };
+      }
+    ).spawnProcess = () => ({
+      process: fakeProcess,
+      command: "kiro-cli acp",
+    });
+
+    const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+    manager.on("event", (event) => {
+      events.push(event as { type: string; payload?: Record<string, unknown> });
+    });
+
+    const session = await manager.startSession({
+      threadId: ThreadId.makeUnsafe("thread-1"),
+      runtimeMode: "full-access",
+      resumeCursor: { sessionId: "session-stale" },
+    });
+
+    expect(session.resumeCursor).toEqual({ sessionId: "session-fresh" });
+    expect(fakeProcess.kill).not.toHaveBeenCalled();
+    expect(fakeProcess.stdin.write).toHaveBeenCalledTimes(3);
+    expect(fakeProcess.stdin.write).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('"method":"session/load"'),
+    );
+    expect(fakeProcess.stdin.write).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining('"method":"session/new"'),
+    );
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "session.started",
+          payload: expect.objectContaining({
+            message: "Starting a new Kiro thread.",
+          }),
+        }),
+        expect.objectContaining({
+          type: "thread.started",
+          payload: expect.objectContaining({
+            providerThreadId: "session-fresh",
+            message: "Connected to thread session-fresh",
+          }),
+        }),
+      ]),
+    );
+  });
+
   it("emits turn.completed when ACP sends turn_end", async () => {
     const manager = new KiroAcpManager();
     const session = createTestSession();

--- a/apps/server/src/kiroAcpManager.ts
+++ b/apps/server/src/kiroAcpManager.ts
@@ -274,6 +274,16 @@ function readResumeSessionId(resumeCursor: unknown): string | undefined {
   );
 }
 
+function isRecoverableResumeLoadError(error: unknown): boolean {
+  const normalized = toErrorMessage(error).toLowerCase();
+  return (
+    normalized.includes("internal error") ||
+    normalized.includes("unknown session") ||
+    normalized.includes("not found") ||
+    normalized.includes("closed")
+  );
+}
+
 function kiroSessionStartedMessage(sessionId: string | undefined): string {
   return sessionId ? `Attempting to resume thread ${sessionId}.` : "Starting a new Kiro thread.";
 }
@@ -810,6 +820,7 @@ export class KiroAcpManager extends EventEmitter {
     };
 
     const resumeSessionId = readResumeSessionId(input.resumeCursor);
+    let resumedSession = false;
     let threadOpenMethod: "session/new" | "session/load" = "session/new";
     logger.info("kiro thread opening", {
       threadId: input.threadId,
@@ -832,9 +843,36 @@ export class KiroAcpManager extends EventEmitter {
         if (modeState) {
           session.modeState = modeState;
         }
+        resumedSession = true;
       } catch (error) {
-        process.kill();
-        throw error;
+        if (!isRecoverableResumeLoadError(error)) {
+          process.kill();
+          throw error;
+        }
+        logger.warn("kiro session/load fell back to session/new", {
+          threadId: input.threadId,
+          requestedRuntimeMode: input.runtimeMode,
+          requestedModel: input.model ?? null,
+          requestedCwd: input.cwd ?? null,
+          requestedResumeThreadId: resumeSessionId,
+          cause: toErrorMessage(error),
+        });
+        threadOpenMethod = "session/new";
+        session.sessionId = undefined;
+        const created = asRecord(
+          await rpc.request("session/new", {
+            ...(input.cwd ? { cwd: input.cwd } : {}),
+            mcpServers: [],
+          }),
+        );
+        const sessionId = normalizeNonEmpty(asString(created?.sessionId));
+        if (sessionId) {
+          session.sessionId = sessionId;
+        }
+        const modeState = extractModeState(created);
+        if (modeState) {
+          session.modeState = modeState;
+        }
       } finally {
         session.suppressReplay = false;
       }
@@ -887,7 +925,7 @@ export class KiroAcpManager extends EventEmitter {
       this.runtimeEvent(session, {
         type: "session.started",
         payload: {
-          message: kiroSessionStartedMessage(resumeSessionId),
+          message: kiroSessionStartedMessage(resumedSession ? resumeSessionId : undefined),
           resume: resumeCursorFromSessionId(session.sessionId),
         },
       }),
@@ -898,7 +936,7 @@ export class KiroAcpManager extends EventEmitter {
         type: "thread.started",
         payload: {
           providerThreadId: session.sessionId,
-          message: kiroThreadConnectedMessage(session.sessionId, Boolean(resumeSessionId)),
+          message: kiroThreadConnectedMessage(session.sessionId, resumedSession),
         },
       }),
     );

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -616,7 +616,7 @@ it.effect("ProviderServiceLive falls back to a fresh Kiro session when resume st
             reconnectState?: string;
             reconnectSummary?: string;
           };
-          assert.equal(runtimePayload.reconnectState, "fresh-start");
+          assert.equal(runtimePayload.reconnectState, "resume-fallback-fresh-start");
           assert.equal(
             runtimePayload.reconnectSummary,
             "Persisted provider session was unavailable; started a new provider session.",
@@ -859,7 +859,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
   );
 
   it.effect(
-    "marks resume fallback as fresh-start when an adapter returns a new resume cursor",
+    "marks resume fallback as resume-fallback-fresh-start when an adapter returns a new resume cursor",
     () =>
       Effect.gen(function* () {
         const provider = yield* ProviderService;
@@ -916,7 +916,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
               reconnectState?: string;
               reconnectSummary?: string;
             };
-            assert.equal(runtimePayload.reconnectState, "fresh-start");
+            assert.equal(runtimePayload.reconnectState, "resume-fallback-fresh-start");
             assert.equal(
               runtimePayload.reconnectSummary,
               "Persisted provider session was unavailable; started a new provider session.",

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -858,6 +858,74 @@ routing.layer("ProviderServiceLive routing", (it) => {
       }),
   );
 
+  it.effect(
+    "marks resume fallback as fresh-start when an adapter returns a new resume cursor",
+    () =>
+      Effect.gen(function* () {
+        const provider = yield* ProviderService;
+        const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+
+        const initial = yield* provider.startSession(asThreadId("thread-1"), {
+          provider: "codex",
+          threadId: asThreadId("thread-1"),
+          cwd: "/tmp/project-send-turn",
+          runtimeMode: "full-access",
+        });
+
+      yield* routing.codex.stopAll();
+      routing.codex.startSession.mockImplementationOnce((input) =>
+        Effect.sync(() => {
+          const now = new Date().toISOString();
+          return {
+              provider: "codex" as const,
+              status: "ready" as const,
+              runtimeMode: input.runtimeMode,
+              threadId: input.threadId,
+              resumeCursor:
+                input.resumeCursor !== undefined
+                  ? { opaque: `replacement-${String(input.threadId)}` }
+                  : { opaque: `cursor-${String(input.threadId)}` },
+              cwd: input.cwd ?? process.cwd(),
+              createdAt: now,
+            updatedAt: now,
+          };
+        }),
+      );
+      routing.codex.sendTurn.mockImplementationOnce((input) =>
+        Effect.succeed({
+          threadId: input.threadId,
+          turnId: TurnId.makeUnsafe(`turn-${String(input.threadId)}`),
+        }),
+      );
+
+      yield* provider.sendTurn({
+        threadId: initial.threadId,
+        input: "resume",
+          attachments: [],
+        });
+
+        const recoveredRuntime = yield* runtimeRepository.getByThreadId({
+          threadId: initial.threadId,
+        });
+        assert.equal(Option.isSome(recoveredRuntime), true);
+        if (Option.isSome(recoveredRuntime)) {
+          const payload = recoveredRuntime.value.runtimePayload;
+          assert.equal(payload !== null && typeof payload === "object", true);
+          if (payload !== null && typeof payload === "object" && !Array.isArray(payload)) {
+            const runtimePayload = payload as {
+              reconnectState?: string;
+              reconnectSummary?: string;
+            };
+            assert.equal(runtimePayload.reconnectState, "fresh-start");
+            assert.equal(
+              runtimePayload.reconnectSummary,
+              "Persisted provider session was unavailable; started a new provider session.",
+            );
+          }
+        }
+      }),
+  );
+
   it.effect("recovers stale sessions for sendTurn using persisted cwd", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService;

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -122,6 +122,42 @@ function toRuntimePayloadFromSession(
   };
 }
 
+const RESUME_FALLBACK_RECONNECT_SUMMARY =
+  "Persisted provider session was unavailable; started a new provider session.";
+
+function readResumeCursorIdentity(resumeCursor: unknown): string | undefined {
+  const providerThreadId = readProviderThreadIdFromResumeCursor(resumeCursor);
+  if (providerThreadId) {
+    return `thread:${providerThreadId}`;
+  }
+  if (!resumeCursor || typeof resumeCursor !== "object" || Array.isArray(resumeCursor)) {
+    return undefined;
+  }
+  const record = resumeCursor as Record<string, unknown>;
+  const sessionId = typeof record.sessionId === "string" ? record.sessionId.trim() : "";
+  if (sessionId.length > 0) {
+    return `session:${sessionId}`;
+  }
+  const resume = typeof record.resume === "string" ? record.resume.trim() : "";
+  if (resume.length > 0) {
+    return `resume:${resume}`;
+  }
+  try {
+    return JSON.stringify(resumeCursor);
+  } catch {
+    return undefined;
+  }
+}
+
+function didResumeCursorFallback(input: {
+  readonly requestedResumeCursor: unknown;
+  readonly resumedResumeCursor: unknown;
+}): boolean {
+  const requested = readResumeCursorIdentity(input.requestedResumeCursor);
+  const resumed = readResumeCursorIdentity(input.resumedResumeCursor);
+  return requested !== undefined && resumed !== undefined && requested !== resumed;
+}
+
 function readPersistedModelSelection(
   runtimePayload: ProviderRuntimeBinding["runtimePayload"],
 ): ModelSelection | undefined {
@@ -328,8 +364,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               session,
               strategy: "resume-fallback-fresh-start" as const,
               reconnectState: "fresh-start" as const,
-              reconnectSummary:
-                "Persisted provider session was unavailable; started a new provider session.",
+              reconnectSummary: RESUME_FALLBACK_RECONNECT_SUMMARY,
             })),
           );
 
@@ -339,19 +374,33 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             ...(hasResumeCursor ? { resumeCursor: input.binding.resumeCursor } : {}),
           })
           .pipe(
-            Effect.map((session) => ({
-              session,
-              strategy: "resume-thread" as const,
-              reconnectState: "resume-thread" as const,
-              reconnectSummary: (() => {
-                const resumedProviderThreadId = readProviderThreadIdFromResumeCursor(
-                  session.resumeCursor,
-                );
-                return resumedProviderThreadId
+            Effect.map((session) => {
+              if (
+                hasResumeCursor &&
+                didResumeCursorFallback({
+                  requestedResumeCursor: input.binding.resumeCursor,
+                  resumedResumeCursor: session.resumeCursor,
+                })
+              ) {
+                return {
+                  session,
+                  strategy: "resume-fallback-fresh-start" as const,
+                  reconnectState: "fresh-start" as const,
+                  reconnectSummary: RESUME_FALLBACK_RECONNECT_SUMMARY,
+                };
+              }
+              const resumedProviderThreadId = readProviderThreadIdFromResumeCursor(
+                session.resumeCursor,
+              );
+              return {
+                session,
+                strategy: "resume-thread" as const,
+                reconnectState: "resume-thread" as const,
+                reconnectSummary: resumedProviderThreadId
                   ? `Reconnected to remote provider thread ${resumedProviderThreadId}.`
-                  : "Resumed the persisted remote provider session.";
-              })(),
-            })),
+                  : "Resumed the persisted remote provider session.",
+              };
+            }),
             Effect.catchTags({
               ProviderAdapterSessionNotFoundError: (error) =>
                 input.binding.provider === "kiro"

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -123,7 +123,7 @@ function toRuntimePayloadFromSession(
 }
 
 const RESUME_FALLBACK_RECONNECT_SUMMARY =
-  "Persisted provider session was unavailable; started a new provider session.";
+  "Persisted provider session was unavailable; started a new provider session." as const;
 
 function readResumeCursorIdentity(resumeCursor: unknown): string | undefined {
   const providerThreadId = readProviderThreadIdFromResumeCursor(resumeCursor);
@@ -363,7 +363,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             Effect.map((session) => ({
               session,
               strategy: "resume-fallback-fresh-start" as const,
-              reconnectState: "fresh-start" as const,
+              reconnectState: "resume-fallback-fresh-start" as const,
               reconnectSummary: RESUME_FALLBACK_RECONNECT_SUMMARY,
             })),
           );
@@ -385,7 +385,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                 return {
                   session,
                   strategy: "resume-fallback-fresh-start" as const,
-                  reconnectState: "fresh-start" as const,
+                  reconnectState: "resume-fallback-fresh-start" as const,
                   reconnectSummary: RESUME_FALLBACK_RECONNECT_SUMMARY,
                 };
               }

--- a/apps/web/src/lib/threadReconnectToast.test.ts
+++ b/apps/web/src/lib/threadReconnectToast.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { ProjectId, ThreadId } from "@t3tools/contracts";
+
+import { buildThreadRestartToastMarker } from "./threadReconnectToast";
+import type { Thread } from "../types";
+
+function createThread(
+  overrides: Partial<Thread> & {
+    session?: Thread["session"];
+  } = {},
+): Thread {
+  return {
+    id: ThreadId.makeUnsafe("thread-1"),
+    codexThreadId: null,
+    projectId: ProjectId.makeUnsafe("project-1"),
+    title: "Thread 1",
+    modelSelection: {
+      provider: "codex",
+      model: "gpt-5.3-codex",
+    },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    session: null,
+    messages: [],
+    proposedPlans: [],
+    error: null,
+    createdAt: "2026-04-04T00:00:00.000Z",
+    updatedAt: "2026-04-04T00:00:00.000Z",
+    latestTurn: null,
+    projectPath: "/tmp/project-1",
+    branch: [],
+    worktreePath: [],
+    turnDiffSummaries: [],
+    activities: [],
+    ...overrides,
+  };
+}
+
+describe("buildThreadRestartToastMarker", () => {
+  it("returns a marker for resume fallback fresh starts", () => {
+    expect(
+      buildThreadRestartToastMarker(
+        createThread({
+          session: {
+            provider: "kiro",
+            status: "ready",
+            orchestrationStatus: "ready",
+            reconnectState: "fresh-start",
+            reconnectSummary:
+              "Persisted provider session was unavailable; started a new provider session.",
+            reconnectUpdatedAt: "2026-04-04T00:01:00.000Z",
+            createdAt: "2026-04-04T00:00:00.000Z",
+            updatedAt: "2026-04-04T00:01:00.000Z",
+          },
+        }),
+      ),
+    ).toBe(
+      "fresh-start:2026-04-04T00:01:00.000Z:Persisted provider session was unavailable; started a new provider session.",
+    );
+  });
+
+  it("does not return a marker for normal fresh starts", () => {
+    expect(
+      buildThreadRestartToastMarker(
+        createThread({
+          session: {
+            provider: "codex",
+            status: "ready",
+            orchestrationStatus: "ready",
+            reconnectState: "fresh-start",
+            reconnectSummary: "Started a new provider session.",
+            reconnectUpdatedAt: "2026-04-04T00:01:00.000Z",
+            createdAt: "2026-04-04T00:00:00.000Z",
+            updatedAt: "2026-04-04T00:01:00.000Z",
+          },
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("does not return a marker for resumed sessions", () => {
+    expect(
+      buildThreadRestartToastMarker(
+        createThread({
+          session: {
+            provider: "claudeAgent",
+            status: "ready",
+            orchestrationStatus: "ready",
+            reconnectState: "resume-thread",
+            reconnectSummary: "Resumed the persisted remote provider session.",
+            reconnectUpdatedAt: "2026-04-04T00:01:00.000Z",
+            createdAt: "2026-04-04T00:00:00.000Z",
+            updatedAt: "2026-04-04T00:01:00.000Z",
+          },
+        }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/lib/threadReconnectToast.test.ts
+++ b/apps/web/src/lib/threadReconnectToast.test.ts
@@ -45,7 +45,7 @@ describe("buildThreadRestartToastMarker", () => {
             provider: "kiro",
             status: "ready",
             orchestrationStatus: "ready",
-            reconnectState: "fresh-start",
+            reconnectState: "resume-fallback-fresh-start",
             reconnectSummary:
               "Persisted provider session was unavailable; started a new provider session.",
             reconnectUpdatedAt: "2026-04-04T00:01:00.000Z",
@@ -54,9 +54,7 @@ describe("buildThreadRestartToastMarker", () => {
           },
         }),
       ),
-    ).toBe(
-      "fresh-start:2026-04-04T00:01:00.000Z:Persisted provider session was unavailable; started a new provider session.",
-    );
+    ).toBe("resume-fallback-fresh-start:2026-04-04T00:01:00.000Z");
   });
 
   it("does not return a marker for normal fresh starts", () => {

--- a/apps/web/src/lib/threadReconnectToast.ts
+++ b/apps/web/src/lib/threadReconnectToast.ts
@@ -2,20 +2,14 @@ import type { Thread } from "../types";
 
 export const THREAD_RESTART_TOAST_TITLE = "Thread Could Not be Restarted, Starting New Thread";
 
-const RESUME_FALLBACK_RECONNECT_SUMMARY =
-  "Persisted provider session was unavailable; started a new provider session.";
-
 export function buildThreadRestartToastMarker(thread: Pick<Thread, "session">): string | null {
   const session = thread.session;
   if (!session) {
     return null;
   }
-  if (session.reconnectState !== "fresh-start") {
-    return null;
-  }
-  if (session.reconnectSummary !== RESUME_FALLBACK_RECONNECT_SUMMARY) {
+  if (session.reconnectState !== "resume-fallback-fresh-start") {
     return null;
   }
   const updatedAt = session.reconnectUpdatedAt ?? session.updatedAt;
-  return `${session.reconnectState}:${updatedAt}:${session.reconnectSummary}`;
+  return `${session.reconnectState}:${updatedAt}`;
 }

--- a/apps/web/src/lib/threadReconnectToast.ts
+++ b/apps/web/src/lib/threadReconnectToast.ts
@@ -1,0 +1,21 @@
+import type { Thread } from "../types";
+
+export const THREAD_RESTART_TOAST_TITLE = "Thread Could Not be Restarted, Starting New Thread";
+
+const RESUME_FALLBACK_RECONNECT_SUMMARY =
+  "Persisted provider session was unavailable; started a new provider session.";
+
+export function buildThreadRestartToastMarker(thread: Pick<Thread, "session">): string | null {
+  const session = thread.session;
+  if (!session) {
+    return null;
+  }
+  if (session.reconnectState !== "fresh-start") {
+    return null;
+  }
+  if (session.reconnectSummary !== RESUME_FALLBACK_RECONNECT_SUMMARY) {
+    return null;
+  }
+  const updatedAt = session.reconnectUpdatedAt ?? session.updatedAt;
+  return `${session.reconnectState}:${updatedAt}:${session.reconnectSummary}`;
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -25,6 +25,10 @@ import { onServerConfigUpdated, onServerWelcome } from "../wsNativeApi";
 import { providerQueryKeys } from "../lib/providerReactQuery";
 import { projectQueryKeys } from "../lib/projectReactQuery";
 import { collectActiveTerminalThreadIds } from "../lib/terminalStateCleanup";
+import {
+  buildThreadRestartToastMarker,
+  THREAD_RESTART_TOAST_TITLE,
+} from "../lib/threadReconnectToast";
 
 export const Route = createRootRouteWithContext<{
   queryClient: QueryClient;
@@ -54,6 +58,7 @@ function RootRouteView() {
       <AnchoredToastProvider>
         <AppSettingsWatcher />
         <EventRouter />
+        <ThreadReconnectToastWatcher />
         <DesktopProjectBootstrap />
         <Outlet />
       </AnchoredToastProvider>
@@ -357,6 +362,45 @@ function AppSettingsWatcher() {
     previousSettingsSignatureRef.current = settingsSignature;
     dismissLocalCodexErrors(new Date().toISOString());
   }, [dismissLocalCodexErrors, settingsSignature]);
+
+  return null;
+}
+
+function ThreadReconnectToastWatcher() {
+  const threads = useStore((store) => store.threads);
+  const previousMarkersRef = useRef<Map<string, string | null> | null>(null);
+
+  useEffect(() => {
+    const nextMarkers = new Map<string, string | null>();
+    for (const thread of threads) {
+      nextMarkers.set(thread.id, buildThreadRestartToastMarker(thread));
+    }
+
+    const previousMarkers = previousMarkersRef.current;
+    previousMarkersRef.current = nextMarkers;
+    if (previousMarkers === null) {
+      return;
+    }
+
+    for (const thread of threads) {
+      const nextMarker = nextMarkers.get(thread.id) ?? null;
+      if (nextMarker === null) {
+        continue;
+      }
+      const previousMarker = previousMarkers.get(thread.id) ?? null;
+      if (previousMarker === nextMarker) {
+        continue;
+      }
+      toastManager.add({
+        type: "warning",
+        title: THREAD_RESTART_TOAST_TITLE,
+        description: thread.session?.reconnectSummary,
+        data: {
+          threadId: thread.id,
+        },
+      });
+    }
+  }, [threads]);
 
   return null;
 }

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -220,6 +220,7 @@ export type OrchestrationSessionStatus = typeof OrchestrationSessionStatus.Type;
 
 export const OrchestrationSessionReconnectState = Schema.Literals([
   "fresh-start",
+  "resume-fallback-fresh-start",
   "adopt-existing",
   "resume-thread",
   "resume-unavailable",


### PR DESCRIPTION
- Fall back to a fresh Kiro session when resume/load is unrecoverable
- Treat provider resume cursor replacement as a fresh-start reconnect
- Add a web toast marker for restart fallback sessions
- Use a dedicated `resume-fallback-fresh-start` reconnect state to distinguish system-initiated fallbacks from user-initiated fresh starts

## What Changed

- **`kiroAcpManager.ts`**: When `session/load` fails with a recoverable error (e.g. "unknown session", "internal error"), gracefully fall back to `session/new` instead of killing the process and throwing.
- **`ProviderService.ts`**: Kiro-specific `ProviderAdapterSessionNotFoundError` and `ProviderAdapterSessionClosedError` are caught and converted to a fresh-start fallback. Resume cursor replacement (where the adapter returns a different cursor than requested) is also detected and treated as a fallback. Both paths now set `reconnectState: "resume-fallback-fresh-start"`.
- **`packages/contracts/src/orchestration.ts`**: Added `"resume-fallback-fresh-start"` to `OrchestrationSessionReconnectState` — a dedicated value for system-initiated fallback sessions, distinct from the user-initiated `"fresh-start"`.
- **`threadReconnectToast.ts`**: New web module that builds a toast marker for resume-fallback sessions. Detection is now based on the type-safe `reconnectState` field rather than string-matching a duplicated summary constant.
- **`__root.tsx`**: Added `ThreadReconnectToastWatcher` component that watches thread sessions and shows a warning toast when a resume fallback occurs.

## Why

When a Kiro provider session cannot be resumed (e.g. the remote session expired), the previous behavior would terminate the connection with an error. The fix gracefully recovers by starting a new session and notifies the user via a toast so they are aware the thread started fresh rather than resuming where it left off.

The `reconnectSummary` string was previously duplicated between the server and web to drive toast detection, creating a fragile coupling. Using a dedicated contract state eliminates that coupling and makes the intent explicit and type-safe.

## Validation

- Unit tests added for `KiroAcpManager` covering the `session/load` → `session/new` fallback path
- Unit tests added for `ProviderService` covering the Kiro `ProviderAdapterSessionNotFoundError` fallback and resume cursor replacement detection
- Unit tests added for `buildThreadRestartToastMarker` covering fallback, normal fresh-start, and resumed session cases

## Maintenance Impact

- `OrchestrationSessionReconnectState` in contracts gains a new literal `"resume-fallback-fresh-start"`. Existing `"fresh-start"` remains for user-initiated sessions. Any consumer reading `reconnectState` should handle the new value.
- The duplicated `RESUME_FALLBACK_RECONNECT_SUMMARY` constant on the web side has been removed; toast detection is now purely state-based.

## UI Changes

A warning toast is displayed when a thread reconnects with a new provider session instead of resuming the previous one. No visual component changes.

## Checklist